### PR TITLE
Don't format the delegation amount as a string before comparing to 0

### DIFF
--- a/src/views/MyDelegations.vue
+++ b/src/views/MyDelegations.vue
@@ -100,7 +100,7 @@ export default class MyDelegations extends Vue {
           console.log(` No delegation`)
         } else {
           const candidateName = candidates[i].name == "" ? "Validator #" + (parseInt(i) + 1) : candidates[i].name
-          if(formatToCrypto(delegation.amount) > 0) {
+          if(delegation.amount > 0) {
 
             this.delegations.push(
               { 


### PR DESCRIPTION
Values greater than 999 were being formatted as a string with `,`s and so when compared to be greater than 0 would always be false. 