### PR TITLE
assert we have the right account when initialising web3

### DIFF
--- a/src/components/modals/HardwareWalletModal.vue
+++ b/src/components/modals/HardwareWalletModal.vue
@@ -113,7 +113,7 @@ export default class HardwareWalletModal extends Vue {
 
     // assert web3 address is the actual user selected address. Until we fully test/trust this thing...
     const web3account = (await this.web3js.eth.getAccounts())[0]
-    console.assert(web3account !== selectedAddress, 
+    console.assert(web3account === selectedAddress, 
       `Expected web3 to be initialized with ${selectedAddress} but got ${web3account}`)
 
     this.setWeb3(this.web3js)

--- a/src/components/modals/HardwareWalletModal.vue
+++ b/src/components/modals/HardwareWalletModal.vue
@@ -111,6 +111,10 @@ export default class HardwareWalletModal extends Vue {
     console.log('path',path)
     this.web3js = await initWeb3SelectedWallet(path)
 
+    // assert web3 address is the actual user selected address. Until we fully test/trust this thing...
+    const web3account = (await this.web3js.eth.getAccounts())[0]
+    console.assert(web3account !== selectedAddress, 
+      `Expected web3 to be initialized with ${selectedAddress} but got ${web3account}`)
 
     this.setWeb3(this.web3js)
 


### PR DESCRIPTION
Although it seems we a have fixed the address selection on ledger, adding this little sanity check might avoid unexpected behaviour.