### PR TITLE
Remove multiple calls to initialize

### DIFF
--- a/src/components/FaucetSidebar.vue
+++ b/src/components/FaucetSidebar.vue
@@ -8,16 +8,16 @@
     </b-nav-item>    
     <div id="restricted-access-links" @click="clickHandler">
       <b-nav-item>
-        <router-link to="/account" :class="[ !userIsLoggedIn ? 'router disabled' : 'router' ]" exact-active-class="router-active">{{ $t('components.faucet_sidebar.my_account') }}</router-link>
+        <router-link to="/account" :class="[ !userIsLoggedIn || !walletType ? 'router disabled' : 'router' ]" exact-active-class="router-active">{{ $t('components.faucet_sidebar.my_account') }}</router-link>
       </b-nav-item>
       <b-nav-item>
-        <router-link to="/delegations" :class="[ !userIsLoggedIn ? 'router disabled' : 'router' ]" exact-active-class="router-active">{{ $t('components.faucet_sidebar.my_delegations') }}</router-link>
+        <router-link to="/delegations" :class="[ !userIsLoggedIn || !walletType ? 'router disabled' : 'router' ]" exact-active-class="router-active">{{ $t('components.faucet_sidebar.my_delegations') }}</router-link>
       </b-nav-item>
       <b-nav-item>
-        <router-link to="/history" :class="[ !userIsLoggedIn ? 'router disabled' : 'router' ]" exact-active-class="router-active">{{ $t('components.faucet_sidebar.history') }}</router-link>
+        <router-link to="/history" :class="[ !userIsLoggedIn || !walletType ? 'router disabled' : 'router' ]" exact-active-class="router-active">{{ $t('components.faucet_sidebar.history') }}</router-link>
       </b-nav-item>      
       <b-nav-item>
-        <router-link to="/rewards" :class="[ !userIsLoggedIn ? 'router disabled' : 'router' ]" exact-active-class="router-active">{{ $t('components.faucet_sidebar.rewards') }}</router-link>
+        <router-link to="/rewards" :class="[ !userIsLoggedIn || !walletType ? 'router disabled' : 'router' ]" exact-active-class="router-active">{{ $t('components.faucet_sidebar.rewards') }}</router-link>
       </b-nav-item>  
     </div>
   </b-nav>
@@ -28,9 +28,14 @@ import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
 import { mapGetters, mapState, mapActions, mapMutations, createNamespacedHelpers } from 'vuex'
 
+const DPOSStore = createNamespacedHelpers('DPOS')
+
 @Component({
   computed: {
-    ...mapState(['userIsLoggedIn'])
+    ...mapState(['userIsLoggedIn']),
+    ...DPOSStore.mapState([
+      'walletType'
+    ])
   }
 })
 

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -185,25 +185,13 @@ export default class Layout extends Vue {
     // Clear any remaining local storage
     localStorage.clear()
       
-    if(this.$route.meta.requireDeps) {
-      this.attemptToInitialize()     
-    } else {
-      this.$root.$on('login', async () => {
-        this.attemptToInitialize()
-      })
-    }      
-    
-    if(window.ethereum) {
-      window.ethereum.on('accountsChanged', (accounts) => {
-        if (this.currentMetamaskAddress && 
-          this.currentMetamaskAddress !== accounts[0] ) {
-                localStorage.clear()
-                this.metamaskChangeAlert = true
-                window.ethereum.removeAllListeners()
-        }
-
-      })
-    }
+    // if(this.$route.meta.requireDeps) {
+    //   this.attemptToInitialize()     
+    // } else {
+    //   this.$root.$on('login', async () => {
+    //     this.attemptToInitialize()
+    //   })
+    // } 
 
   }
 

--- a/src/components/modals/HardwareWalletModal.vue
+++ b/src/components/modals/HardwareWalletModal.vue
@@ -331,6 +331,7 @@ export default class HardwareWalletModal extends Vue {
   }
 
   async show(myWeb3) {
+    this.setShowLoadingSpinner(false)
     this.componentLoaded = true
     await this.setWeb3Instance()
     try {

--- a/src/views/FirstPage.vue
+++ b/src/views/FirstPage.vue
@@ -288,7 +288,7 @@ export default class FirstPage extends Vue {
   }
 
   async onWalletConfig() {
-    this.setWalletType("ledger")
+    await this.initializeDependencies()
   }
 
 }</script>

--- a/src/views/FirstPage.vue
+++ b/src/views/FirstPage.vue
@@ -166,10 +166,23 @@ export default class FirstPage extends Vue {
 
   async selectWallet(wallet) {
     if(wallet === "ledger") {
-      this.setWalletType("ledger")
-     this.$refs.hardwareWalletConfigRef.show() 
+      
+      try {
+        this.$refs.hardwareWalletConfigRef.show()
+        this.setWalletType("ledger")
+      } catch(err) {
+        this.setShowLoadingSpinner(false)
+        console.log(err)
+      }
     } else if(wallet === "metamask") {
       this.setWalletType("metamask")
+      if(window.ethereum) {
+        window.ethereum.on('accountsChanged', async (accounts) => {
+          if(this.userIsLoggedIn) this.ensureIdentityMappingExists({currentAddress: accounts[0]})
+          this.setCurrentMetamaskAddress(accounts[0])
+        })
+      }
+      await this.initializeDependencies()
     } else {
       return
     }


### PR DESCRIPTION
- Disable menu if not logged in and no wallet type detected.
- Only call initialise dependencies function once.
- Add spinner when opening hardware wallet modal.