### PR TITLE
Mobile Validators page and optimize dpos store

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -111,7 +111,7 @@ button {
 }
 
 h1, h2, h3 {
-  color: #fff;
+  //color: #fff;
   // font-family: $font-family-kalisto;
 }
 .color-blue {

--- a/src/components/FaucetHeader.vue
+++ b/src/components/FaucetHeader.vue
@@ -337,7 +337,8 @@ export default class FaucetHeader extends Vue {
       }, waitTime * 1000)
     }
   }
-}</script>
+}
+</script>
 <style lang="scss">
 .header {
   background: #5756e6;
@@ -451,15 +452,6 @@ a.hover-warning:hover {
 .metamask-status-error {
   background-color: #e62e2e;
 }
-
-// #balance::after {
-//   position: absolute;
-//   content: "Staked / Available";
-//   font-size: 9px;
-//   color: #ffffff;
-//   bottom: 6px;
-//   left: 8px;
-// }
 
 .add-border-left {
   border-left: 2px solid #f2f1f3;

--- a/src/components/FaucetHeader.vue
+++ b/src/components/FaucetHeader.vue
@@ -36,6 +36,11 @@
                   <router-link to="/history" class="router text-light hover-warning">History</router-link>
                 </h5>
               </li>
+              <li>
+                <h5>
+                  <router-link to="/validators" class="router text-light hover-warning">Validators</router-link>
+                </h5>
+              </li>
 
             </b-navbar-nav>
           </b-collapse>        

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -5,9 +5,6 @@
       <warning-overlay type="metamask"></warning-overlay>
       <warning-overlay type="mapping"></warning-overlay>
       <div class="row">
-        <!-- <div v-show="showSidebar" class="col-lg-3">
-          <faucet-sidebar></faucet-sidebar>     
-        </div> -->
         <div class="col rmv-spacing">
           <b-modal id="sign-wallet-modal"  title="Sign Your wallet" hide-footer centered no-close-on-backdrop> 
               {{ $t('components.layout.sign_wallet', {walletType:walletType}) }}
@@ -20,7 +17,6 @@
         </div>        
       </div>          
     </div>    
-    <!-- <faucet-footer></faucet-footer> -->
      <b-modal id="metamaskChangeDialog" no-close-on-backdrop hider-header hide-footer centered v-model="metamaskChangeAlert">
         <div class="d-block text-center">
           <p>{{ $t('components.layout.metamask_changed')}}</p>
@@ -43,9 +39,6 @@ import WarningOverlay from '../components/WarningOverlay'
 const DappChainStore = createNamespacedHelpers('DappChain')
 const DPOSStore = createNamespacedHelpers('DPOS')
 
-import { initWeb3 } from '../services/initWeb3'
-import { isIP } from 'net';
-
 @Component({
   components: {
     FaucetHeader,
@@ -59,20 +52,12 @@ import { isIP } from 'net';
   },
   methods: {
     ...mapMutations([
-      'setUserIsLoggedIn',
       'setErrorMsg'
     ]),
     ...DappChainStore.mapActions([
-      'ensureIdentityMappingExists'
     ]),
     ...DPOSStore.mapActions([
       'initializeDependencies',
-      'checkMappingAccountStatus'
-    ]),
-    ...DPOSStore.mapMutations([
-      'setConnectedToMetamask',
-      'setCurrentMetamaskAddress',
-      'setWalletType'
     ]),
     ...DappChainStore.mapMutations([
       'setMappingError',
@@ -85,21 +70,16 @@ import { isIP } from 'net';
     ]),
     ...DappChainStore.mapState([
       'account',
-      'metamaskStatus',
       'metamaskError',
-      'mappingStatus',
       'mappingError'
     ]),
     ...DPOSStore.mapState([
       'showSidebar',
-      'web3',
       "currentMetamaskAddress",
-      'metamaskDisabled',
       'showLoadingSpinner',
       'showAlreadyMappedModal',
       'showSignWalletModal',
       'mappingSuccess',
-      'isLoggedIn',
       'walletType',
       'status'
     ])    
@@ -110,9 +90,6 @@ export default class Layout extends Vue {
 
   metamaskChangeAlert = false
 
-  pendingModalTitle = 'Continue with your approved Loom'
-  isOpen = true
-  preload = false
   loginEmail = ''
   routeArray = [
     {
@@ -132,9 +109,7 @@ export default class Layout extends Vue {
   ]
 
   created() {
-    this.$router.afterEach((to, from) => {
-      this.$root.$emit("refreshBalances")
-    })
+    this.$router.afterEach((to, from) => this.$root.$emit("refreshBalances"))
   }
 
   beforeMount() {
@@ -170,12 +145,11 @@ export default class Layout extends Vue {
   }
 
   @Watch('showSignWalletModal')
-    onSignLedgerModalChange(newValue, oldValue) {      
+  onSignLedgerModalChange(newValue, oldValue) {      
     if(newValue) {
         this.$root.$emit("bv::show::modal", "sign-wallet-modal")
     } else {
         this.$root.$emit("bv::hide::modal", "sign-wallet-modal")
-
     }
   }
 
@@ -229,18 +203,6 @@ export default class Layout extends Vue {
     }           
   }
 
-  onLoginHandler() {
-    this.$auth.initAuthInstance()
-  }
-
-  get showErrorMsg() {
-    return this.$store.state.errorMsg ? { message: this.$store.state.errorMsg, variant: 'error' } : false
-  }
-
-  get showSuccessMsg() {
-    return this.$store.state.successMsg ? { message: this.$store.state.successMsg, variant: 'success' } : false
-  }
-
   get getClassNameForStyling() {
     let className = "";
     const self = this;
@@ -252,12 +214,8 @@ export default class Layout extends Vue {
     })
     return className;
   }
-
-  get contentClass() {
-    return this.showSidebar ? 'col-lg-9' : 'col-lg-12'
-  }
-
-}</script>
+}
+</script>
 
 <style lang="scss" scoped>
   #layout {

--- a/src/store/dappChainStore.js
+++ b/src/store/dappChainStore.js
@@ -9,6 +9,10 @@ import { getDomainType, formatToCrypto, toBigNumber, isBigNumber, getValueOfUnit
 import LoomTokenJSON from '../contracts/LoomToken.json'
 import GatewayJSON from '../contracts/Gateway.json'
 import { ethers } from 'ethers'
+import Debug from "debug"
+
+Debug.enable("dashboard.dapp")
+const debug = Debug("dashboard.dapp")
 
 const coinMultiplier = new BN(10).pow(new BN(18));
 

--- a/src/store/dappChainStore.js
+++ b/src/store/dappChainStore.js
@@ -148,7 +148,8 @@ const defaultState = () => {
     mappingError: undefined,
     metamaskStatus: undefined,
     metamaskError: undefined,
-    isConnectedToDappChain: false
+    isConnectedToDappChain: false,
+    validators: [],
   }
 }
 
@@ -477,26 +478,21 @@ export default {
           // If there is a validator, set its stakes to the corresponding amounts.
           if (v !== undefined) {
               validator.active = true
-
               // Tokens amount of tokens staked (sum of personal and delegated)
               validator.totalStaked = new BN(v.whitelistAmount).add(new BN(stakedTokens[addr])).toString()
-
               // How much was validator personally staked
               validator.personalStake = v.whitelistAmount.toString()
-
               // how much tokens staked by delegators
               validator.delegatedStake = stakedTokens[addr] ? stakedTokens[addr].toString() : 0
-      
               // Voting Power is the whitelist plus the tokens w/ bonuses
               validator.votingPower = v.delegationTotal.toString()
-
               validator.delegationsTotal = new BN(v.delegationTotal).sub(v.whitelistAmount).toString()
           }
-          
-
           validators.push(validator)
       }
 
+      state.validators = validators
+      debug("validators refreshed")
       return validators
     },
     async getAccumulatedStakingAmount({ state, dispatch }, payload) {

--- a/src/store/dposStore.js
+++ b/src/store/dposStore.js
@@ -32,7 +32,7 @@ const defaultState = () => {
     currentMetamaskAddress: undefined,
     history: null,
     withdrawLimit: DAILY_WITHDRAW_LIMIT,
-    validators: null,
+    validators: [],
     status: "check_mapping",
     walletType: undefined,
     selectedAccount: undefined,
@@ -50,6 +50,8 @@ const defaultState = () => {
     },
     rewardsResults: null,
     timeUntilElectionCycle: null,
+    // timestamp millis
+    nextElectionTime: 0,
     validatorFields: [
       { key: 'Name', sortable: true },
       { key: 'Status', sortable: true },
@@ -127,6 +129,9 @@ export default {
     },
     setTimeUntilElectionCycle(state, payload) {
       state.timeUntilElectionCycle = payload
+    },
+    setNextElectionTime(state, millis) {
+      state.nextElectionTime = millis
     },
     setWalletType(state, payload) {
       state.walletType = payload
@@ -361,7 +366,9 @@ export default {
       }
       
     },    
-
+    // this can be moved out as is automatically called once dposUser is set
+    // actually instead of depending on dposUser we should depend on dpos contract
+    // (if we want to display timer in "anonymous" session)
     async getTimeUntilElectionsAsync({ rootState, dispatch, commit }) {
       
       if(!rootState.DappChain.dposUser) {
@@ -372,7 +379,9 @@ export default {
 
       try {
         const result = await user.getTimeUntilElectionsAsync()
+        debug("next election in %s seconds", result.toString())
         commit("setTimeUntilElectionCycle", result.toString())
+        commit("setNextElectionTime", Date.now() + (result.toNumber()*1000))
       } catch(err) {
         console.error(err)
       }

--- a/src/store/dposStore.js
+++ b/src/store/dposStore.js
@@ -82,7 +82,45 @@ export default {
     },
     getCachedEvents(state) {
       return state.cachedEvents || JSON.parse(sessionStorage.getItem("cachedEvents")) || []
-    }
+    },
+    getFormattedValidators(state, getters, rootState) {
+
+      return rootState.DappChain.validators.map((validator) => {
+
+        let Weight = 0
+        if ( validator.name.startsWith("plasma-") )  {
+          Weight = 1
+        } else if( validator.name === "" ) {
+          Weight = 2
+        }
+        // Check if bootstrap val
+        const validatorName = validator.name !== "" ? validator.name : validator.address
+        const isBootstrap = state.prohibitedNodes.includes(validatorName)
+        return {
+          Address: validator.address,
+          pubKey: (validator.pubKey),
+          // Active / Inactive validator
+          Status: validator.active ? "Active" : "Inactive",
+          totalStaked: formatToCrypto(validator.totalStaked),
+          delegationsTotal: formatToCrypto(validator.delegationsTotal),
+          personalStake: formatToCrypto(validator.personalStake),
+          delegatedStake: formatToCrypto(validator.delegatedStake),
+          // Whitelist + Tokens Staked * Bonuses
+          votingPower: formatToCrypto(validator.votingPower || 0),
+          // Validator MEtadata
+          Name: validatorName,
+          Description: (validator.description) || null,
+          Website: (validator.website) || null,
+          Fees: isBootstrap ? 'N/A' : (validator.fee  || '0') + '%',
+          isBootstrap,
+          Weight,            
+          _cellVariants:  {
+            Status: validator.active ? 'active' : 'inactive',
+            Name:  isBootstrap ? "danger" : undefined
+          },
+        }
+      }).sort(dynamicSort("Weight"))
+    },
   },  
   mutations: {
     setIsLoggedIn(state, payload) {

--- a/src/views/ValidatorList.vue
+++ b/src/views/ValidatorList.vue
@@ -7,40 +7,16 @@
       <p><fa icon="info-circle" fixed-width /> {{ $t("Staking is disabled on bootstrap validators.")}}</p>
       <template v-if="isSmallDevice">
         <b-list-group>
-          <b-list-group-item class="flex-column align-items-start" 
+          <b-list-group-item 
+            v-for="validator in validators" :key="validator.Name"
             :class="{disabled:validator.isBoostrap}"
-            v-for="validator in validators" :key="validator.Name">
-            <header class="d-flex w-100 justify-content-between">
-              <h5 class="mb-1">{{validator.Name}}</h5>
-              <small :class="{'active': validator.Status === 'Active'}">{{validator.Status}}</small>
-            </header>
-            <dl>
-              <dt>Fees</dt>
-              <dd>{{validator.Fees}}</dd>
-              <dt>Total Stakes</dt>
-              <dd>{{validator.totalStaked}}</dd>
-              <dt>Your Stakes</dt>
-              <dd>0.00</dd>
-            </dl>
-            <footer>
-              <b-button size="sm" variant="outline-primary">more</b-button>
-              <b-button size="sm" variant="outline-primary">Stake</b-button>
-            </footer>
+            >
+              <h6>{{validator.Name}}</h6>
+              <div class="stakes"><label>Stake</label><span>{{validator.totalStaked}}</span></div>
+              <div class="status" :class="{'active': validator.Status === 'Active'}">{{validator.Status}}</div>
+              <div class="fee"><label>Fee</label>{{validator.Fees}}</div>
           </b-list-group-item>  
         </b-list-group>
-        <b-card v-for="validator in validators" :key="validator.Name" :title="validator.Name">
-          <b-card-sub-title class="mb-2" :class="{'node-active': validator.Status === 'Active'}">{{validator.Status}}</b-card-sub-title>
-          <b-card-text>
-            <dl>
-              <dt>Fees</dt>
-              <dd>{{validator.Fees}}</dd>
-              <dt>Total Stakes</dt>
-              <dd>{{validator.totalStaked}}</dd>
-              <dt>Your Stakes</dt>
-              <dd>0.00</dd>
-            </dl>
-          </b-card-text>
-        </b-card>
       </template>
       <template v-else>
         <faucet-table :items="validators" :fields="validatorFields" sortBy="Weight" :rowClass="validatorCssClass" @row-clicked="showValidatorDetail"></faucet-table>
@@ -118,59 +94,41 @@ main.validators {
   }
 
   .list-group-item {
-      padding-top: 16px;
-    > header {
-      margin-bottom: 4px;
-
+    padding-top: 16px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    > h6 {
+      flex: 1
     }
-    .active {
+    .stakes > label {
+      display: block;
+      display: none;
+      margin: 0;
+      font-size: 12px;
+      line-height: 12px;
+      text-align: right;
+    }
+    .fee > label {
+      display: inline-block;
+      margin: 0;
+      font-size: 12px;
+      line-height: 24px;
+      text-align: right;
+      vertical-align: bottom;
+      margin-right: 7px;
+      font-weight: bold;
+      color: rgba(128, 128, 128, 0.58);
+    }
+    .status {
+      flex: 50%;
+      font-size: 0.8em;
+      &.active {
         color: green
-    }
-    > footer {
-      display: flex;
-      justify-content: flex-end;
-      margin-bottom: 8px;
-      > button {
-        width: 25%;
-        margin-left: 4px 
       }
     }
   }
 
-
-  .card {
-    margin: 16px 0;
-
-    .active {
-      color: green
-    }
-  }
-  .card-title {
-    font-size: 1.1em;
-  }
-  dl {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-  dt,dd {
-    flex: 50%;
-    margin: 0;
-    border-top: 1px solid #ededed;
-    padding: 4px 0;
-  }
-  dt {
-    font-size: 0.8em;
-    line-height: 24px;
-    font-weight: normal;
-  }
-  dd {
-    font-size: 1em;
-    line-height: 24px;
-    text-align: right;
-    font-weight: normal;
-    color: black;
-  }
 }
 
 .faucet {

--- a/src/views/ValidatorList.vue
+++ b/src/views/ValidatorList.vue
@@ -49,41 +49,29 @@ import { DPOSUser, CryptoUtils, LocalAddress } from "loom-js";
     ...mapMutations([
       'setErrorMsg'
     ]),
-    ...DPOSStore.mapMutations([
-      'setValidators'
-    ]),
-    ...DPOSStore.mapActions([
-      'getValidatorList'
-    ]),
-    ...DappChainStore.mapActions([
-      'getValidatorsAsync',
-      'getDpos2'
+    ...DPOSStore.mapGetters([
+      'getFormattedValidators'
     ])
   }
 })
 export default class ValidatorList extends Vue {
+  isSmallDevice = window.innerWidth < 600
 
-  async mounted() {
-    await this.refresh()
+  get validators() {
+    return this.getFormattedValidators()
   }
-
-  async refresh() {
-    await this.getDpos2()
-    await this.getValidatorList()
-  }
-
   /**
    * adds class bootstrap node if is bootstrap
    */
   validatorCssClass( item, type) {
-    console.log(34943034)
     return item.isBoostrap ? ['boostrap-validator'] : []
   } 
 
   showValidatorDetail(record, index) {
     this.$router.push(`/validator/${encodeURIComponent(record.Name)}`)
   }
-}</script>
+}
+</script>
 
 <style lang="scss">
 @import url('https://use.typekit.net/nbq4wog.css');

--- a/src/views/ValidatorList.vue
+++ b/src/views/ValidatorList.vue
@@ -27,8 +27,6 @@ import Vue from 'vue'
 import ApiClient from '../services/faucet-api'
 import { Component, Watch } from 'vue-property-decorator'
 import FaucetTable from '../components/FaucetTable'
-import FaucetHeader from '../components/FaucetHeader'
-import FaucetFooter from '../components/FaucetFooter'
 import LoadingSpinner from '../components/LoadingSpinner'
 import { mapGetters, mapState, mapActions, mapMutations, createNamespacedHelpers } from 'vuex'
 const DappChainStore = createNamespacedHelpers('DappChain')
@@ -36,16 +34,14 @@ const DPOSStore = createNamespacedHelpers('DPOS')
 
 import { DPOSUser, CryptoUtils, LocalAddress } from "loom-js";
 
+
 @Component({
   components: {
     FaucetTable,
-    FaucetHeader,
-    FaucetFooter,
     LoadingSpinner,
   },
   computed: {
     ...DPOSStore.mapState([
-      'validators',
       'validatorFields'
     ])
   },

--- a/src/views/ValidatorList.vue
+++ b/src/views/ValidatorList.vue
@@ -1,25 +1,55 @@
 <template>
-  <div class="faucet">
-    <div class="faucet-content">
-      <div>
-        <main>
-          <div class="container mb-5 column py-3 p-3 d-flex" v-if="validators !== null && validators.length > 0">
-            <h1>{{ $t('views.validator_list.validators') }}</h1>
-            <p><fa icon="info-circle" fixed-width /> Staking is disabled on bootstrap validators.</p>
-            <faucet-table :items="validators" :fields="validatorFields" sortBy="Weight" :rowClass="validatorCssClass" @row-clicked="showValidatorDetail"></faucet-table>
-          </div>
-          <div v-else-if="validators !== null && validators.length == 0">
-            <h2>
-              {{ $t('views.validator_list.no_validators_available_please_try') }}
-            </h2>
-          </div>
-          <div class="container mb-5 column py-3 p-3 d-flex" v-else>            
-            <loading-spinner :showBackdrop="true"></loading-spinner>
-          </div>
-        </main>
-      </div>
+  <main class="validators">
+    <header>
+      <h1>{{ $t('views.validator_list.validators') }}</h1>
+    </header>
+    <div class="content" v-if="validators && validators.length > 0">
+      <p><fa icon="info-circle" fixed-width /> {{ $t("Staking is disabled on bootstrap validators.")}}</p>
+      <template v-if="isSmallDevice">
+        <b-list-group>
+          <b-list-group-item class="flex-column align-items-start" 
+            :class="{disabled:validator.isBoostrap}"
+            v-for="validator in validators" :key="validator.Name">
+            <header class="d-flex w-100 justify-content-between">
+              <h5 class="mb-1">{{validator.Name}}</h5>
+              <small :class="{'active': validator.Status === 'Active'}">{{validator.Status}}</small>
+            </header>
+            <dl>
+              <dt>Fees</dt>
+              <dd>{{validator.Fees}}</dd>
+              <dt>Total Stakes</dt>
+              <dd>{{validator.totalStaked}}</dd>
+              <dt>Your Stakes</dt>
+              <dd>0.00</dd>
+            </dl>
+            <footer>
+              <b-button size="sm" variant="outline-primary">more</b-button>
+              <b-button size="sm" variant="outline-primary">Stake</b-button>
+            </footer>
+          </b-list-group-item>  
+        </b-list-group>
+        <b-card v-for="validator in validators" :key="validator.Name" :title="validator.Name">
+          <b-card-sub-title class="mb-2" :class="{'node-active': validator.Status === 'Active'}">{{validator.Status}}</b-card-sub-title>
+          <b-card-text>
+            <dl>
+              <dt>Fees</dt>
+              <dd>{{validator.Fees}}</dd>
+              <dt>Total Stakes</dt>
+              <dd>{{validator.totalStaked}}</dd>
+              <dt>Your Stakes</dt>
+              <dd>0.00</dd>
+            </dl>
+          </b-card-text>
+        </b-card>
+      </template>
+      <template v-else>
+        <faucet-table :items="validators" :fields="validatorFields" sortBy="Weight" :rowClass="validatorCssClass" @row-clicked="showValidatorDetail"></faucet-table>
+      </template>
     </div>
-  </div>
+    <div class="container mb-5 column py-3 p-3 d-flex" v-else>            
+      <loading-spinner :showBackdrop="true"></loading-spinner>
+    </div>
+  </main>
 </template>
 
 <script>

--- a/src/views/ValidatorList.vue
+++ b/src/views/ValidatorList.vue
@@ -104,19 +104,74 @@ export default class ValidatorList extends Vue {
 </script>
 
 <style lang="scss">
-@import url('https://use.typekit.net/nbq4wog.css');
 
-$theme-colors: (
-  //primary: #007bff,
-  primary: #02819b,
-  secondary: #4bc0c8,
-  success: #5cb85c,
-  info: #5bc0de,
-  warning: #f0ad4e,
-  danger: #d9534f,
-  light: #f0f5fd,
-  dark: #122a38
-);
+main.validators {
+  // ther should be global class for page titles
+  header > h1 {
+    color: #5246d5;
+    font-size: 1.35em;
+    text-align: center;
+    margin: 16px -14px;
+    font-weight: normal;
+    border-bottom: 1px solid #ededed;
+    padding-bottom: 16px;
+  }
+
+  .list-group-item {
+      padding-top: 16px;
+    > header {
+      margin-bottom: 4px;
+
+    }
+    .active {
+        color: green
+    }
+    > footer {
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 8px;
+      > button {
+        width: 25%;
+        margin-left: 4px 
+      }
+    }
+  }
+
+
+  .card {
+    margin: 16px 0;
+
+    .active {
+      color: green
+    }
+  }
+  .card-title {
+    font-size: 1.1em;
+  }
+  dl {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  dt,dd {
+    flex: 50%;
+    margin: 0;
+    border-top: 1px solid #ededed;
+    padding: 4px 0;
+  }
+  dt {
+    font-size: 0.8em;
+    line-height: 24px;
+    font-weight: normal;
+  }
+  dd {
+    font-size: 1em;
+    line-height: 24px;
+    text-align: right;
+    font-weight: normal;
+    color: black;
+  }
+}
 
 .faucet {
   main {
@@ -146,10 +201,8 @@ $theme-colors: (
       opacity: 0.5
     }
   }
-
-
 }
-  body {
-    overflow-y: scroll;
-  }
+body {
+  overflow-y: scroll;
+}
 </style>


### PR DESCRIPTION
- election time is now automatically tracked as soon as dposUser is available (Vuex.watch)
- candidates/validators are automatically refreshed, once per election cycle (maybe we could schedule more refreshes for safety) (Vuex.watch)

Which leads to:
- `DPOS/getTimeUntilElectionsAsync` should no more be called from components. Instead components can read the already available `state.DPOS.timeUntilElectionCycle` (seconds) and the new `state.DPOS.nextElectionTime` (timestamp millis)
- `DappChain/getValidatorsAsync` should no more be called from components (unless it is for a manual refresh button) 

the validators page might still need a little aesthetic tuning...

![image](https://user-images.githubusercontent.com/200361/54743667-c1b32e80-4bff-11e9-863f-00fec2c2bd14.png)
