### PR TITLE
DPoS reports without dposUser

### DIFF
--- a/src/store/dappChainStore.js
+++ b/src/store/dappChainStore.js
@@ -602,8 +602,21 @@ export default {
         new Address(chainId, LocalAddress.fromPublicKey(publicKey)))
       return result
     },
+    /**
+     * If an initialized/initializing dposUser is in the state
+     * return dposUser.dappchainDPOS
+     * else creates one (and the client that goes with it...)
+     * @param {DappChainState} param0 
+     * @param {*} payload ?
+     * @returns {Promise<DPOS2>}
+     */
     async getDpos2({ state, commit }, payload) {
-      if (!payload && state.dpos2) {
+      if (state.dposUser) {
+        // todo check state.dpos2 and remove it/disconnect its client
+        // since we have dposUser now
+        return (await state.dposUser).dappchainDPOS
+      }
+      else if (state.dpos2) {
         commit('setDappChainConnected', true)
         return state.dpos2
       }

--- a/src/store/dappChainStore.js
+++ b/src/store/dappChainStore.js
@@ -614,7 +614,7 @@ export default {
       if (state.dposUser) {
         // todo check state.dpos2 and remove it/disconnect its client
         // since we have dposUser now
-        return (await state.dposUser).dappchainDPOS
+        return state.dposUser.dappchainDPOS
       }
       else if (state.dpos2) {
         commit('setDappChainConnected', true)

--- a/src/store/dposStore.js
+++ b/src/store/dposStore.js
@@ -465,15 +465,9 @@ export default {
     // actually instead of depending on dposUser we should depend on dpos contract
     // (if we want to display timer in "anonymous" session)
     async getTimeUntilElectionsAsync({ rootState, dispatch, commit }) {
-      
-      if(!rootState.DappChain.dposUser) {
-        await dispatch("DappChain/initDposUser", null, { root: true })
-      }
-
-      const user = rootState.DappChain.dposUser
-
+      const dpos = await dispatch("DappChain/getDpos2", null, { root: true })
       try {
-        const result = await user.getTimeUntilElectionsAsync()
+        const result = await dpos.getTimeUntilElectionAsync()
         debug("next election in %s seconds", result.toString())
         commit("setTimeUntilElectionCycle", result.toString())
         commit("setNextElectionTime", Date.now() + (result.toNumber()*1000))


### PR DESCRIPTION
- getTimeUntilElection and getValidators call store.getDpos2()
-  store.getDpos2() returns dposUser.dappchainDpos if dposUser is present create client and dpos contract if not
- vuex plugin trigger getTimeUntilElection immediately on start up.
- account view mount() waits for dposUser if not set