### PR TITLE
Plasma history reverse chronological order

### DIFF
--- a/src/store/dposStore.js
+++ b/src/store/dposStore.js
@@ -497,7 +497,7 @@ export default {
 
     async fetchDappChainEvents({ state, commit, dispatch }, payload) {
 
-      let historyPromise = axios.get(`${state.dappChainEventUrl}/eth:${state.currentMetamaskAddress}`)
+      let historyPromise = axios.get(`${state.dappChainEventUrl}/eth:${state.currentMetamaskAddress}?sort=-block_height`)
       // Store the unresolved promise
       commit("setHistoryPromise", historyPromise)
       


### PR DESCRIPTION
Lock added the ability to sort events. So this should fix the history page.