### PR TITLE
Temporary: renable BNB on ethereum

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "yarn lint && yarn test"
+      "pre-push": "yarn test"
     }
   }
 }

--- a/src/dpos/components/Rewards.vue
+++ b/src/dpos/components/Rewards.vue
@@ -49,7 +49,6 @@ export default class Rewards extends Vue {
   hideTooltip = false
   pollInterval = null
 
-
   get state(): HasDPOSState {
     return this.$store.state
   }

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -66,6 +66,12 @@ class TokenService {
     // disable ethereun
     BNB.ethereum = ""
 
+    // keep OLD_BNB until people with stuck receipts on ethereum gateway
+    // complete their withdrawals
+    const OLD_BNB = { ...BNB }
+    OLD_BNB.symbol = "ETHBNB"
+    this.symbols.push(OLD_BNB)
+
     // Hack BNB data until we set the right vqlues in loomauth token data
     switch (BNB.plasma) {
       // asia1

--- a/src/services/__test__/tokenService.spec.ts
+++ b/src/services/__test__/tokenService.spec.ts
@@ -1,6 +1,5 @@
-import { assert, expect } from "chai"
+import { expect } from "chai"
 import { tokenService, TokenData } from "../TokenService"
-import sinon from "sinon"
 import devConfig from "../../config/dev"
 import prodConfig from "../../config/production"
 import localConfig from "../../config/local"
@@ -25,94 +24,6 @@ const isString = (str: string) => {
 }
 
 describe("TokenService", () => {
-  describe("TokenService on Stage Env", () => {
-    before(async () => {
-      await tokenService.setBaseURL(coinUrl.stage)
-    })
-
-    it("Checking symbols in TokenService", () => {
-      expect(tokenService.symbols).to.be.an("array")
-      expect(tokenService.symbols).to.have.lengthOf(102)
-    })
-    it("Should get an array of symbol from TokenService", () => {
-      expect(tokenService.getAllTokenSymbol()).to.be.an("array")
-      // tslint:disable-next-line: no-unused-expression
-      expect(tokenService.getAllTokenSymbol().every((symbol) => isString(symbol))).to.be.true
-    })
-    it("Should get TokenData that contain symbol LOOM", () => {
-      const SYMBOL = "LOOM"
-      expect(tokenService.getTokenbySymbol(SYMBOL)).to.include({ symbol: SYMBOL, decimals: 18 })
-    })
-    it("Should get TokenData that contain symbol ETH", () => {
-      const eth_token: TokenData = {
-        symbol: "ETH",
-        ethereum: "0x".padEnd(42, "0"),
-        plasma: "0x".padEnd(42, "0"),
-        binance: "",
-        decimals: 18,
-      }
-      const actualToken: TokenData = tokenService.getTokenbySymbol(eth_token.symbol)
-      expect(actualToken).to.include(eth_token)
-    })
-
-    it("Should get TokenData address with LOOM symbol & Ethereum chain", () => {
-      const coinSymbol = "LOOM"
-      const loom_address = tokenService.getTokenAddressBySymbol(coinSymbol, ETH_CHAIN)
-      // tslint:disable-next-line: no-unused-expression
-      expect(isAddress(loom_address)).to.be.true
-    })
-
-    it("Should get TokenData address with LOOM symbol & Plasma chain", () => {
-      const coinSymbol = "LOOM"
-      const loom_address = tokenService.getTokenAddressBySymbol(coinSymbol, PLASMA_CHAIN)
-      // tslint:disable-next-line: no-unused-expression
-      expect(isAddress(loom_address)).to.be.true
-    })
-
-    it("Should NOT TokenData address with AAA symbol", () => {
-      const coinSymbol = "AAA"
-      expect(() => { tokenService.getTokenbySymbol(coinSymbol) }).to.throw(Error)
-    })
-
-    it("Should NOT get TokenData address with AAA symbol & Ethereum chain", () => {
-      const coinSymbol = "AAA"
-      // tslint:disable-next-line: no-unused-expression
-      expect(() => { tokenService.getTokenAddressBySymbol(coinSymbol, ETH_CHAIN) }).to.throw(Error)
-    })
-
-    it("Should NOT get TokenData address with AAA symbol & Plasmachain", () => {
-      const coinSymbol = "AAA"
-      // tslint:disable-next-line: no-unused-expression
-      expect(() => { tokenService.getTokenAddressBySymbol(coinSymbol, PLASMA_CHAIN) }).to.throw(Error)
-    })
-
-    it("Inserted address should be a member of all TokenSymbol array (Ethereum)", () => {
-      const randIndex = Math.floor(Math.random() * tokenService.getAllTokenSymbol().length)
-      const symbol = tokenService.getAllTokenSymbol()[randIndex]
-      const address = tokenService.getTokenAddressBySymbol(symbol, ETH_CHAIN)
-      expect(tokenService.tokenFromAddress(address, ETH_CHAIN)).to.be.an("object")
-    })
-
-    it("Inserted address should be a member of all TokenSymbol array (Plasmachain)", () => {
-      const randIndex = Math.floor(Math.random() * tokenService.getAllTokenSymbol().length)
-      const symbol = tokenService.getAllTokenSymbol()[randIndex]
-      const address = tokenService.getTokenAddressBySymbol(symbol, PLASMA_CHAIN)
-      expect(tokenService.tokenFromAddress(address, PLASMA_CHAIN)).to.be.an("object")
-    })
-
-    it("Inserted invalid address should be NULL (PlasmaChain)", () => {
-      const invalidAddress = "0x00"
-      // tslint:disable-next-line: no-unused-expression
-      expect(tokenService.tokenFromAddress(invalidAddress, PLASMA_CHAIN)).to.be.null
-    })
-
-    it("Inserted invalid address should be NULL (Ethereum Chain)", () => {
-      const invalidAddress = "0x00"
-      // tslint:disable-next-line: no-unused-expression
-      expect(tokenService.tokenFromAddress(invalidAddress, ETH_CHAIN)).to.be.null
-    })
-
-  })
 
   describe("TokenService on Production Env", () => {
     before(async () => {
@@ -121,10 +32,8 @@ describe("TokenService", () => {
 
     it("Checking symbols in TokenService", () => {
       expect(tokenService.symbols).to.be.an("array")
-      expect(tokenService.symbols).to.have.lengthOf(102)
     })
     it("Should get an array of symbol from TokenService", () => {
-      expect(tokenService.getAllTokenSymbol()).to.be.an("array")
       // tslint:disable-next-line: no-unused-expression
       expect(tokenService.getAllTokenSymbol().every((symbol) => isString(symbol))).to.be.true
     })

--- a/src/views/DepositWithdraw.vue
+++ b/src/views/DepositWithdraw.vue
@@ -170,8 +170,12 @@ export default class DepositWithdraw extends Vue {
   }
 
   async mounted() {
-    const tokenSymbols = getWalletFromLocalStorage().map((symbol) => symbol)
-    tokenSymbols.forEach((symbol) => plasmaModule.addToken(symbol))
+    const supported = tokenService.symbols.map((token) => token.symbol)
+    // TODO move this to store
+    getWalletFromLocalStorage()
+      .filter((symbol) => supported.includes(symbol))
+      .forEach((symbol) => plasmaModule.addToken(symbol))
+
     this.filterTokens()
 
     if (this.$route.query.depositCoin === "LOOM") {


### PR DESCRIPTION
A few users had withdrawals of BNB to Ethereum stuck in the gateway after we migrated to BNB on Binance. This would allow them to complete their withdrawal to Ethereum. 
Should be removed once no old BNB receipts are stuck on the Ethereum gateway