### PR TITLE
Hotfix: Limbo rewards

### DIFF
--- a/src/dpos/store/index.ts
+++ b/src/dpos/store/index.ts
@@ -409,7 +409,7 @@ async function claimRewards(context: ActionContext) {
   feedback.setStep(i18n.t("feedback_msg.step.checking_reward").toString())
   const limboDelegations = await contract.checkDelegationAsync(
     limboValidator,
-    contract.caller,
+    plasmaModule.getAddress(),
   )
   if (limboDelegations!.delegationsArray.length > 0) {
     feedback.setStep(i18n.t("feedback_msg.step.claiming_dpos_reward").toString()) // add amount

--- a/src/store/plasma/index.ts
+++ b/src/store/plasma/index.ts
@@ -120,7 +120,7 @@ function setConfig(state: PlasmaState, config: PlasmaConfig) {
 
 // getter
 function getAddress(state: PlasmaState): Address {
-  const chainId = "default" // state.chainId
+  const chainId = state.chainId
   return new Address(chainId, LocalAddress.fromHexString(state.address))
 }
 


### PR DESCRIPTION
Address arguments are not recovered. Only caller is mapped/recovered (#1155)