### PR TITLE
Temporarily disable on going ethereum withdrawals check

### DIFF
--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -5,7 +5,7 @@ export default {
   plasma: {
     networkId: "plasma",
     chainId: "default",
-    endpoint: "wss://plasma.dappchains.com",
+    endpoint: "wss://basechain.dappchains.com",
     blockExplorer: "https://basechain-blockexplorer.dappchains.com",
     loomGamesEndpoint: "https://loom.games/en/dpos-link",
     historyUrl: "https://api.loom.games/plasma/address/{address}?sort=-block_height",

--- a/src/store/gateway/reactions.ts
+++ b/src/store/gateway/reactions.ts
@@ -145,7 +145,6 @@ export function gatewayReactions(store: Store<DashboardState>) {
    * checks incomplete withdawals
    */
   async function checkIncompleteTransfers() {
-    console.log("checkIncompleteTransfers")
     const plasmaGateways = PlasmaGateways.service()
     const loomReceipt = await plasmaGateways.get("ethereum", "LOOM").withdrawalReceipt()
     const mainReceipt = await plasmaGateways.get("ethereum", "ETH").withdrawalReceipt()

--- a/src/store/gateway/reactions.ts
+++ b/src/store/gateway/reactions.ts
@@ -145,13 +145,18 @@ export function gatewayReactions(store: Store<DashboardState>) {
    * checks incomplete withdawals
    */
   async function checkIncompleteTransfers() {
-
+    console.log("checkIncompleteTransfers")
     const plasmaGateways = PlasmaGateways.service()
     const loomReceipt = await plasmaGateways.get("ethereum", "LOOM").withdrawalReceipt()
     const mainReceipt = await plasmaGateways.get("ethereum", "ETH").withdrawalReceipt()
-    if (!loomReceipt && !mainReceipt) return
+    // console.log("receipts", loomReceipt, mainReceipt)
 
-    const pastWithdrawalExist = await gatewayModule.checkIfPastWithdrawalEventExists()
+    if (!loomReceipt && !mainReceipt) return
+    // console.log("receipts", loomReceipt, mainReceipt)
+
+    // Disable checking pending ethereum withdrawal transaction.
+    // worse that could happen is 1 transaction succeeding and the second failing.
+    const pastWithdrawalExist = false // await gatewayModule.checkIfPastWithdrawalEventExists()
     if (loomReceipt && !pastWithdrawalExist) {
       gatewayModule.setWithdrawalReceipts(loomReceipt)
       return


### PR DESCRIPTION
Disabling verification of ongoing withdrawals on ethereum side. Which we do in case a receipt is present. The check is used to avoid sending an other withdrawal request in case one is still unconfirmed on ethereum. The worse that could happen is the second tx failing. Which is fine.