### PR TITLE
Remove the hardcoded withdrawal limits

### DIFF
--- a/src/components/gateway/WithdrawForm.vue
+++ b/src/components/gateway/WithdrawForm.vue
@@ -55,7 +55,7 @@ import { Component, Prop, Watch } from "vue-property-decorator"
 import { ethers } from "ethers"
 
 import { formatTokenAmount } from "@/filters"
-import { formatToCrypto, formatToLoomAddress, ZERO, ETH_WITHDRAW_LIMIT, LOOM_WITHDRAW_LIMIT } from "@/utils"
+import { formatToCrypto, formatToLoomAddress, ZERO } from "@/utils"
 import { DashboardState, Funds } from "@/types"
 import { gatewayModule } from "@/store/gateway"
 import { gatewayReactions } from "@/store/gateway/reactions"
@@ -202,13 +202,7 @@ export default class WithdrawForm extends Vue {
       this.dailyRemainingWithdrawAmount = await this.remainWithdrawAmount()
       this.max = this.balance.lt(this.dailyRemainingWithdrawAmount) ? this.balance : this.dailyRemainingWithdrawAmount
     } else {
-      if (token === "ETH") {
-        this.max = this.balance.lt(ETH_WITHDRAW_LIMIT) ? this.balance : ETH_WITHDRAW_LIMIT
-      } else if (token === "LOOM") {
-        this.max = this.balance.lt(LOOM_WITHDRAW_LIMIT) ? this.balance : LOOM_WITHDRAW_LIMIT
-      } else {
-        this.max = this.balance
-      }
+      this.max = this.balance
     }
     if (fee) {
       const { decimals } = tokenService.getTokenbySymbol(fee.token)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -187,5 +187,3 @@ export function detectedWallet() {
 
   return ""
 }
-export const ETH_WITHDRAW_LIMIT = new BN(300).mul(new BN(10).pow(new BN(18))) // 300 ETH
-export const LOOM_WITHDRAW_LIMIT = new BN(1000000).mul(new BN(10).pow(new BN(18))) // 1 million LOOM


### PR DESCRIPTION
Withdrawal limits can be enforced on-chain, there's no longer any need to hardcode the limits in the UI.