### PR TITLE
Update LOOM token address on Rinkeby again

### DIFF
--- a/scripts/ext-dev.json
+++ b/scripts/ext-dev.json
@@ -3,7 +3,7 @@
     "symbol": "LOOM",
     "name": "Loom",
     "decimals": 18,
-    "ethereum": "0xF0265F31D8Ec34Eb32a2928288a5F12a284eA822",
+    "ethereum": "0xf0265f31d8ec34eb32a2928288a5f12a284ea822",
     "plasma": "0x0e9d499f42dfafe7f0e397f86fee6ab09483f36b",
     "binance": ""
   },

--- a/src/assets/tokens/ext-dev.tokens.json
+++ b/src/assets/tokens/ext-dev.tokens.json
@@ -3,7 +3,7 @@
     "symbol": "LOOM",
     "name": "Loom",
     "decimals": 18,
-    "ethereum": "0xF0265F31D8Ec34Eb32a2928288a5F12a284eA822",
+    "ethereum": "0xf0265f31d8ec34eb32a2928288a5f12a284ea822",
     "plasma": "0x0e9d499f42dfafe7f0e397f86fee6ab09483f36b",
     "binance": "0x0000000000000000000000004c4f4f4d2d394436"
   },


### PR DESCRIPTION
There's some code that assumes the contract addresses are all lowercase, the mixed case used previously caused a few errors.