### PR TITLE
Fix NaN LOOM balance on validator registration form

### DIFF
--- a/src/dpos/components/RegisterCandidateForm.vue
+++ b/src/dpos/components/RegisterCandidateForm.vue
@@ -90,11 +90,10 @@ import Vue from "vue"
 import { HasDPOSState } from "@/dpos/store/types"
 import { Component } from "vue-property-decorator"
 import { Address, CryptoUtils } from "loom-js"
-import { formatToLoomAddress, ZERO, parseToWei } from "../../utils"
+import { ZERO, parseToWei } from "../../utils"
 import { LocktimeTier, CandidateState } from "loom-js/dist/proto/dposv3_pb"
 import { dposModule } from "../store"
 import { formatTokenAmount } from "@/filters"
-import BigNumber from 'bignumber.js';
 import BN from "bn.js"
 
 @Component
@@ -115,9 +114,7 @@ export default class RegisterCandidateForm extends Vue {
   }
 
   get fixedLoomBalance() {
-    const loomBalance = formatTokenAmount(this.state.plasma.coins.LOOM.balance)
-    return new BigNumber(loomBalance).toFixed(2)
-    // return this.state.plasma.coins.LOOM.balance.toNumber()
+    return formatTokenAmount(this.state.plasma.coins.LOOM.balance, 18, 2)
   }
 
   get isStakable() {

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -82,7 +82,8 @@ export function formatUrl(domainOrUrl: string) {
 
 export function formatTokenAmount(wei: BN, decimals = 18, precision?: number) {
   if (!wei) return wei
-  const c = new BigNumber(wei.toString()).dividedBy(10 ** decimals)
+  const d = new BigNumber(10).pow(decimals)
+  const c = new BigNumber(wei.toString()).dividedBy(d)
   return c.toFormat(precision)
 }
 


### PR DESCRIPTION
The problem here was that when the LOOM balance is 1000 or over `formatTokenAmount` returns a string with comma(s) (e.g. "1,000") and the comma(s) trip up the `BigNumber` constructor which then returns a `NaN`.