### PR TITLE
Configure gateway versions for each foreign network

### DIFF
--- a/src/config/dev.ts
+++ b/src/config/dev.ts
@@ -26,6 +26,10 @@ export default {
     },
     portisKey: "10589118-6329-43a0-818c-93800c206786",
     formaticKey: "pk_test_58DB7D96C460470B",
+    gatewayVersions: {
+      loom: 2,
+      main: 2,
+    },
   },
   binance: {
     networkId: "97",
@@ -39,7 +43,11 @@ export default {
     contracts: {
       loomGateway: "0x0cee0FB12205b9Ca9d4Fbed502091dEfD7ae6ff5",
       mainGateway: ethers.constants.AddressZero // NOTE: generic gateway is not deployed on BSC yet
-    }
+    },
+    gatewayVersions: {
+      loom: 1,
+      main: 1,
+    },
   },
   dpos: {
     bootstrapNodes: [],
@@ -48,10 +56,6 @@ export default {
   coinDataUrl: "/tokens/dev.tokens.json",
   gateway: {
     chains: ["ethereum"],
-    multisig: {
-      loom: false,
-      main: true,
-    },
     checkMarketplaceURL: "",
     binance: {
       gatewayAccount: "tbnb14sa7gnlalxd0e336clc0ltgke6e6hdanyl6pqq",

--- a/src/config/ext-dev.ts
+++ b/src/config/ext-dev.ts
@@ -26,6 +26,10 @@ export default {
     },
     portisKey: "10589118-6329-43a0-818c-93800c206786",
     formaticKey: "pk_test_58DB7D96C460470B",
+    gatewayVersions: {
+      loom: 1,
+      main: 2,
+    },
   },
   binance: {
     networkId: "97",
@@ -39,7 +43,11 @@ export default {
     contracts: {
       loomGateway: "0xdeadbeef",
       mainGateway: ethers.constants.AddressZero // NOTE: generic gateway is not deployed on BSC yet
-    }
+    },
+    gatewayVersions: {
+      loom: 1,
+      main: 1,
+    },
   },
   dpos: {
     bootstrapNodes: [],
@@ -48,10 +56,6 @@ export default {
   coinDataUrl: "/tokens/ext-dev.tokens.json",
   gateway: {
     chains: ["ethereum", "binance"],
-    multisig: {
-      loom: false,
-      main: true,
-    },
     checkMarketplaceURL: "",
     tokenContractLogsURL: "",
     binance: {

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -23,6 +23,10 @@ export default {
       gateway: "0xE57e0793f953684Bc9D2EF3D795408afb4a100c3",
       loomGateway: "0x76c41effc2871e73f42b2eae5eaf8efe50bdbf73",
     },
+    gatewayVersions: {
+      loom: 2,
+      main: 2,
+    },
   },
   dpos: {
     bootstrapNodes: [],
@@ -30,10 +34,6 @@ export default {
   },
   gateway: {
     chains: ["ethereum"],
-    multisig: {
-      loom: true,
-      main: true,
-    },
     checkMarketplaceURL: "",
     tokenContractLogsURL: "https://dev-api.loom.games/plasma/tokencontract/eth:{address}",
     binance: {

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -24,6 +24,10 @@ export default {
       mainGateway: "0xe080079ac12521d57573f39543e1725ea3e16dcc",
       loomGateway: "0xfcf1e3fa575a313fd81fea2caa06269b49f1a528",
     },
+    gatewayVersions: {
+      loom: 1,
+      main: 1,
+    },
   },
   binance: {
     networkId: "56",
@@ -37,6 +41,10 @@ export default {
     contracts: {
       mainGateway: ethers.constants.AddressZero, // NOTE: generic gateway is not deployed on BSC yet
       loomGateway: "0xdeadbeef"
+    },
+    gatewayVersions: {
+      loom: 1,
+      main: 1,
     },
   },
   dpos: {
@@ -53,10 +61,6 @@ export default {
   },
   gateway: {
     chains: ["ethereum"],
-    multisig: {
-      loom: false,
-      main: false,
-    },
     checkMarketplaceURL: "https://auth.loom.games/wallet/address?address={address}&wallet=eth",
     tokenContractLogsURL: "https://api.loom.games/plasma/tokencontract/eth:{address}",
     binance: {

--- a/src/store/ethereum/index.ts
+++ b/src/store/ethereum/index.ts
@@ -86,6 +86,10 @@ const initialState: EthereumState = {
   userData: {
     pendingWithdrawal: false,
   },
+  gatewayVersions: {
+    main: 1,
+    loom: 1,
+  }
 }
 
 // web3 instance

--- a/src/store/ethereum/types.ts
+++ b/src/store/ethereum/types.ts
@@ -16,6 +16,10 @@ export interface EthereumConfig {
   contracts: { [name: string]: string }
   formaticKey?: string
   portisKey?: string
+  gatewayVersions: {
+    loom: 1 | 2,
+    main: 1 | 2,
+  },
 }
 
 // Interface for application stores than include EthereumState

--- a/src/store/gateway/index.ts
+++ b/src/store/gateway/index.ts
@@ -20,10 +20,6 @@ const log = debug("dash.gateway")
 
 function initialState(): GatewayState {
   return {
-    multisig: {
-      loom: false,
-      main: false,
-    },
     chains: [],
     mapping: null,
     withdrawalReceipts: null,

--- a/src/store/gateway/reactions.ts
+++ b/src/store/gateway/reactions.ts
@@ -45,7 +45,7 @@ export function gatewayReactions(store: Store<DashboardState>) {
         Sentry.setExtra(mapping.to.chainId, mapping.to.local.toString())
 
         await setPlasmaAccount(mapping)
-        await initializeGateways(mapping, store.state.gateway.multisig)
+        await initializeGateways(mapping, store.state.ethereum.gatewayVersions)
 
         const ethereumGateways = EthereumGateways.service()
 
@@ -117,16 +117,17 @@ export function gatewayReactions(store: Store<DashboardState>) {
     gatewayModule.refreshAllowances()
   }
 
-  async function initializeGateways(mapping: IAddressMapping, multisig: { loom: boolean, main: boolean }) {
+  async function initializeGateways(mapping: IAddressMapping, version: { loom: 1 | 2, main: 1 | 2 }) {
     const addresses = {
       mainGateway: store.state.ethereum.contracts.mainGateway,
       loomGateway: store.state.ethereum.contracts.loomGateway,
     }
+    // Initialize Ethereum gateways & coin contracts
     try {
       const ethereumGateway = await EthereumGateways.init(
         ethereumModule.web3,
         addresses,
-        multisig,
+        version,
       )
       const loomAddr = tokenService.getTokenAddressBySymbol("LOOM", "ethereum")
       ethereumGateway.add("LOOM", loomAddr)
@@ -137,7 +138,6 @@ export function gatewayReactions(store: Store<DashboardState>) {
       console.error("Error initializing ethereum gateways " + error.message)
       return
     }
-    // Initialize Ethereum gateways & coin contracts
 
     // Init plasma side
     try {

--- a/src/store/gateway/types.ts
+++ b/src/store/gateway/types.ts
@@ -15,7 +15,6 @@ export interface HasGatewayState extends HasEthereumState, HasPlasmaState {
 }
 
 export interface GatewayConfig {
-  multisig: { loom: boolean, main: boolean }
   chains: string[]
   checkMarketplaceURL: string
   tokenContractLogsURL: string


### PR DESCRIPTION
Previously the gateway versions were assumed to be the same for BSC and Ethereum, but that's not true in some environments. Now the gateway versions must be set for BSC and Ethereum separately.