### PR TITLE
Upgrade to loom-js@1.75.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "date-fns": "^1.29.0",
     "google-protobuf": "^3.6.0",
     "js-sha256": "^0.9.0",
-    "loom-js": "1.75.2",
+    "loom-js": "1.75.3",
     "marked": "^0.8.0",
     "rxjs": "^6.5.2",
     "truffle-privatekey-provider": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8020,10 +8020,10 @@ lolex@^4.0.1, lolex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz#ecdd7b86539391d8237947a3419aa8ac975f0fe1"
 
-loom-js@1.75.2:
-  version "1.75.2"
-  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.75.2.tgz#45332ff5e111ec2f0eaa982f477027efae55ea87"
-  integrity sha512-g/0Nv6tYU7wN2wlsmZCW9zJmFyYmx3aehll0ooCQj4VcxLy1Zd9fSjnLGR8UA2HDCGRS9FsStFsSL8ytrarkWA==
+loom-js@1.75.3:
+  version "1.75.3"
+  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.75.3.tgz#70454e8da535809e5293da4b75079da3c529009a"
+  integrity sha512-z34nE93xy1m/9Vuu6LrsFO2KbZkUprKxQaNVqtjtBJdNKtJ6Qr9Hdx4qeZmgtWoe44hZAhj8lbVr1ukEnAhyPQ==
   dependencies:
     "@binance-chain/javascript-sdk" "^2.14.5"
     abi-decoder "^1.2.0"


### PR DESCRIPTION
This fixes an issue with fetching info for newly registered validators from the chain.