### PR TITLE
Signing out should disconnect WalletConnect session

### DIFF
--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -142,7 +142,8 @@ export default class Layout extends Vue {
   get networkId() { return this.s.plasma.networkId }
 
   mounted() {
-    this.$root.$on("logout", () => {
+    this.$root.$on("logout", async () => {
+      await ethereumModule.onLogout()
       this.restart()
     })
   }

--- a/src/store/ethereum/index.ts
+++ b/src/store/ethereum/index.ts
@@ -58,6 +58,7 @@ const initialState: EthereumState = {
   address: "",
   signer: null,
   walletType: "",
+  wallet: null,
   walletNetworkId: null,
   balances: {
     ETH: ZERO,
@@ -133,6 +134,8 @@ export const ethereumModule = {
   clearWalletType: builder.commit(clearWalletType),
   commitSetWalletNetworkId: builder.commit(setWalletNetworkId),
 
+  onLogout: builder.dispatch(onLogout),
+
   setToExploreMode: builder.dispatch(setToExploreMode),
   allowance: builder.dispatch(allowance),
 
@@ -184,7 +187,16 @@ async function setProvider(context: ActionContext, p: IWalletProvider) {
   const address = await signer.getAddress()
   context.state.signer = signer
   context.state.address = address
+  context.state.wallet = p.provider || null
   ethereumModule.commitSetWalletNetworkId(p.chainId)
+}
+
+async function onLogout(context: ActionContext) {
+  // yep. Now this module knows about provider inner workings...
+  if (context.state.walletType === "walletconnect") {
+    const wcProvider: any = context.state.wallet
+    await wcProvider.disconnect()
+  }
 }
 
 async function setToExploreMode(context: ActionContext, address: string) {

--- a/src/store/ethereum/index.ts
+++ b/src/store/ethereum/index.ts
@@ -172,7 +172,7 @@ async function setWalletType(context: ActionContext, walletType: string) {
 
     await wallet
       .createProvider(context.state)
-      .then(async provider => await setProvider(context, provider))
+      .then(async (provider) => await setProvider(context, provider))
       .catch((error) => {
         Sentry.captureException(error)
         console.error(error)
@@ -187,15 +187,14 @@ async function setProvider(context: ActionContext, p: IWalletProvider) {
   const address = await signer.getAddress()
   context.state.signer = signer
   context.state.address = address
-  context.state.wallet = p.provider || null
+  context.state.wallet = p
   ethereumModule.commitSetWalletNetworkId(p.chainId)
 }
 
 async function onLogout(context: ActionContext) {
-  // yep. Now this module knows about provider inner workings...
-  if (context.state.walletType === "walletconnect") {
-    const wcProvider: any = context.state.wallet
-    await wcProvider.disconnect()
+  const provider = context.state.wallet
+  if (provider != null) {
+    await provider.disconnect()
   }
 }
 

--- a/src/store/ethereum/types.ts
+++ b/src/store/ethereum/types.ts
@@ -31,8 +31,7 @@ export interface EthereumState extends EthereumConfig {
   address: string
   signer: ethers.Signer | null
   walletType: string
-  // web3 provider == wallet == any!
-  wallet: any | null
+  wallet: IWalletProvider | null
   walletNetworkId: number | null // ID of foreign network the wallet is connected to (if any)
   balances: {
     [erc20Symbol: string]: BN,
@@ -69,7 +68,7 @@ export interface IWalletProvider {
   web3: Web3,
   signer: Signer,
   chainId: number,
-  provider?: any
+  disconnect(): Promise<void>,
 }
 export interface WalletType {
   id: string

--- a/src/store/ethereum/types.ts
+++ b/src/store/ethereum/types.ts
@@ -31,6 +31,8 @@ export interface EthereumState extends EthereumConfig {
   address: string
   signer: ethers.Signer | null
   walletType: string
+  // web3 provider == wallet == any!
+  wallet: any | null
   walletNetworkId: number | null // ID of foreign network the wallet is connected to (if any)
   balances: {
     [erc20Symbol: string]: BN,
@@ -66,7 +68,8 @@ export interface EthereumState extends EthereumConfig {
 export interface IWalletProvider {
   web3: Web3,
   signer: Signer,
-  chainId: number
+  chainId: number,
+  provider?: any
 }
 export interface WalletType {
   id: string
@@ -76,7 +79,7 @@ export interface WalletType {
   detect: () => boolean
   desktop: boolean
   mobile: boolean
-  
+
   createProvider(config: EthereumConfig): Promise<IWalletProvider>
 }
 

--- a/src/store/ethereum/wallets/binance.ts
+++ b/src/store/ethereum/wallets/binance.ts
@@ -24,7 +24,7 @@ export const BinanceChainWalletAdapter: WalletType = {
     bc.autoRefreshOnNetworkChange = false
     // @ts-ignore
     bc.on("chainChanged", () => ethereumModule.commitSetWalletNetworkId(parseInt(window.BinanceChain.chainId, 16)));
-    
+
     let accounts: string[] = []
     try {
       accounts = await bc.request({ method: "eth_requestAccounts" })
@@ -44,11 +44,12 @@ export const BinanceChainWalletAdapter: WalletType = {
       console.log(`accountsChanged ${accounts}`)
       changeAccounts(accounts).catch(err => console.error(err))
     })
-    
+
     return {
       web3: new Web3(bc),
       signer: getMetamaskSigner(bc),
       chainId: parseInt(bc.chainId, 16),
+      disconnect: () => Promise.resolve(),
     }
   },
 }
@@ -65,7 +66,7 @@ async function changeAccounts(accounts: string[]) {
     return
   }
   if (ethereumModule.state.address &&
-      ethereumModule.state.address.toLowerCase() !== accounts[0]) {
+    ethereumModule.state.address.toLowerCase() !== accounts[0]) {
     // Remove any reference to past withdrawals as it is bound to a specific address
     localStorage.removeItem("lastWithdrawTime")
     ethereumModule.state.metamaskChangeAlert = true;

--- a/src/store/ethereum/wallets/metamask.ts
+++ b/src/store/ethereum/wallets/metamask.ts
@@ -38,6 +38,7 @@ export const MetaMaskAdapter: WalletType = {
       web3: new Web3(provider),
       signer,
       chainId: network.chainId,
+      disconnect: () => Promise.resolve(),
     }
   },
 }

--- a/src/store/ethereum/wallets/walletconnect.ts
+++ b/src/store/ethereum/wallets/walletconnect.ts
@@ -37,14 +37,9 @@ export const WalletConnectAdapter: WalletType = {
     wcProvider.on("accountsChanged", (accounts: string[]) => {
       console.log(`WalletConnect accountsChanged ${accounts}`)
     })
-    const onDisconnect = (code, reason) => {
+    wcProvider.on("disconnect", (code, reason) => {
       console.log(`WalletConnect session disconnected, ${code}, reason ${reason}`)
       window.location.reload()
-    }
-    wcProvider.on("disconnect", onDisconnect)
-    window.addEventListener("beforeunload", (_) => {
-      wcProvider.removeListener("disconnect", onDisconnect)
-      wcProvider.disconnect()
     })
 
     // enable session (triggers QR Code modal)
@@ -53,6 +48,7 @@ export const WalletConnectAdapter: WalletType = {
       web3: new Web3(wcProvider),
       signer: getMetamaskSigner(wcProvider),
       chainId: wcProvider.chainId,
+      provider: wcProvider,
     }
   },
 }

--- a/src/store/ethereum/wallets/walletconnect.ts
+++ b/src/store/ethereum/wallets/walletconnect.ts
@@ -34,12 +34,17 @@ export const WalletConnectAdapter: WalletType = {
       }
     )
     // NOTE: WC seems to emit accountsChanged every time the provider is enabled, unlike MetaMask.
-    wcProvider.on("accountsChanged",  (accounts: string[]) => {
+    wcProvider.on("accountsChanged", (accounts: string[]) => {
       console.log(`WalletConnect accountsChanged ${accounts}`)
     })
-    wcProvider.on("disconnect", (code, reason) => {
+    const onDisconnect = (code, reason) => {
       console.log(`WalletConnect session disconnected, ${code}, reason ${reason}`)
       window.location.reload()
+    }
+    wcProvider.on("disconnect", onDisconnect)
+    window.addEventListener("beforeunload", (_) => {
+      wcProvider.removeListener("disconnect", onDisconnect)
+      wcProvider.disconnect()
     })
 
     // enable session (triggers QR Code modal)

--- a/src/store/ethereum/wallets/walletconnect.ts
+++ b/src/store/ethereum/wallets/walletconnect.ts
@@ -48,7 +48,7 @@ export const WalletConnectAdapter: WalletType = {
       web3: new Web3(wcProvider),
       signer: getMetamaskSigner(wcProvider),
       chainId: wcProvider.chainId,
-      provider: wcProvider,
+      disconnect: () => wcProvider.disconnect(),
     }
   },
 }


### PR DESCRIPTION
Currently if the user connects to the dashboard using WalletConnect then signing out doesn't disconnect the session, this makes it hard to recover from certain situations where a user gets stuck half-way through a deposit/withdrawal because they accidentally dismissed a WalletConnect request to sign a tx on their phone. There's a `disconnect` function on the WalletConnect provider that should be called when the user signs out.