### PR TITLE
Don't allow sign in with MetaMask if it's connected to the wrong network

### DIFF
--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -55,7 +55,7 @@
         }}
         {{
           $t("components.layout.please_change_to", {
-            network: s.ethereum.networkName,
+            network: ethereumNets[s.ethereum.networkId],
           })
         }}
       </span>

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -1,16 +1,10 @@
 <template>
   <div id="layout" class="d-flex flex-column">
-    <div v-if="networkId && networkId !== 'plasma'" style="background: #FFC107; padding: 0 16px;">
-      <span>{{ $t('components.layout.network') }} {{networkId}}</span>
-    </div>
     <div
-      v-if="foreignNetworkId !== null && (foreignNetworkId != s.ethereum.networkId)"
-      style="background: #FF9800;padding: 16px 16px;"
+      v-if="networkId && networkId !== 'plasma'"
+      style="background: #ffc107; padding: 0 16px"
     >
-      <span>
-        {{ $t('components.layout.your_wallet_connected_to', { network: ethereumNets[foreignNetworkId] }) }}
-        {{ $t('components.layout.please_change_to', { network: s.ethereum.networkName }) }}
-      </span>
+      <span>{{ $t("components.layout.network") }} {{ networkId }}</span>
     </div>
     <faucet-header></faucet-header>
     <div class="content">
@@ -25,14 +19,20 @@
             hide-footer
             centered
             no-close-on-backdrop
-          >{{ $t('components.layout.sign_wallet', { network: foreignNetworkName }) }}</b-modal>
+            >{{
+              $t("components.layout.sign_wallet", {
+                network: foreignNetworkName,
+              })
+            }}</b-modal
+          >
           <b-modal
             id="already-mapped"
             title="$t('components.layout.account_mapped')"
             hide-footer
             centered
             no-close-on-backdrop
-          >{{ $t('components.layout.already_mapped') }}</b-modal>
+            >{{ $t("components.layout.already_mapped") }}</b-modal
+          >
           <transition name="page" mode="out-in">
             <router-view></router-view>
             <!-- <p class="custom-notification">Scheduled maintance for upgrading to DPOSv3, please check back in a few hours.</p> -->
@@ -40,6 +40,29 @@
         </div>
       </div>
     </div>
+    <b-modal
+      no-close-on-backdrop
+      hide-header
+      hide-footer
+      centered
+      v-model="badWalletNetworkConnected"
+    >
+      <span>
+        {{
+          $t("components.layout.your_wallet_connected_to", {
+            network: ethereumNets[foreignNetworkId],
+          })
+        }}
+        {{
+          $t("components.layout.please_change_to", {
+            network: s.ethereum.networkName,
+          })
+        }}
+      </span>
+      <b-button class="mt-2" variant="primary" block @click="logout"
+        >OK</b-button
+      >
+    </b-modal>
     <b-modal
       id="metamaskChangeDialog"
       no-close-on-backdrop
@@ -49,16 +72,21 @@
       v-model="metamaskChangeAlert"
     >
       <div class="d-block text-center">
-        <p>{{ $t('components.layout.metamask_changed')}}</p>
+        <p>{{ $t("components.layout.metamask_changed") }}</p>
       </div>
-      <b-button class="mt-2" variant="primary" block @click="restart">OK</b-button>
+      <b-button class="mt-2" variant="primary" block @click="restart"
+        >OK</b-button
+      >
     </b-modal>
     <transition
       name="router-anim"
       enter-active-class="animated fadeIn faster"
       leave-active-class="animated fadeOut faster"
     >
-      <loading-spinner v-if="showLoadingSpinner" :showBackdrop="true"></loading-spinner>
+      <loading-spinner
+        v-if="showLoadingSpinner"
+        :showBackdrop="true"
+      ></loading-spinner>
     </transition>
 
     <!-- dpos -->
@@ -142,14 +170,20 @@ export default class Layout extends Vue {
   get networkId() { return this.s.plasma.networkId }
 
   mounted() {
-    this.$root.$on("logout", async () => {
-      await ethereumModule.onLogout()
-      this.restart()
-    })
+    this.$root.$on("logout", () => this.logout())
   }
 
   get metamaskChangeAlert() {
     return ethereumModule.state.metamaskChangeAlert
+  }
+
+  get badWalletNetworkConnected() {
+    return this.foreignNetworkId !== null && String(this.foreignNetworkId) !== this.s.ethereum.networkId
+  }
+
+  async logout() {
+    await ethereumModule.onLogout()
+    this.restart()
   }
 
   restart() {

--- a/src/store/gateway/mapper.ts
+++ b/src/store/gateway/mapper.ts
@@ -25,6 +25,16 @@ export async function loadMapping(context: ActionContext, address: string) {
   const client = context.rootState.plasma.client!
   const chainId = client.chainId
   const caller = context.rootState.plasma.appId.address
+
+  const foreignNetwork = String((context.rootState.ethereum.wallet || {}).chainId)
+  const expectedNetwork = context.rootState.ethereum.networkId
+
+  console.log(foreignNetwork, expectedNetwork)
+  if (foreignNetwork !== expectedNetwork) {
+    // fail silently. UI will pickup the state and let user know
+    return
+  }
+
   feedbackModule.setStep(i18n.t("feedback_msg.step.check_account_mapping").toString())
   const mapper = await AddressMapper.createAsync(
     client,
@@ -80,7 +90,7 @@ export async function createMapping(context: ActionContext, privateKey: string) 
   )
   feedbackModule.setStep(
     i18n.t("feedback_msg.step.create_new_mapping", { network: rootState.ethereum.genericNetworkName }
-  ).toString())
+    ).toString())
   const mapper = await AddressMapper.createAsync(client, address)
   try {
     await mapper.addIdentityMappingAsync(

--- a/src/store/gateway/mapper.ts
+++ b/src/store/gateway/mapper.ts
@@ -26,7 +26,10 @@ export async function loadMapping(context: ActionContext, address: string) {
   const chainId = client.chainId
   const caller = context.rootState.plasma.appId.address
 
-  const foreignNetwork = String((context.rootState.ethereum.wallet || {}).chainId)
+  if (context.rootState.ethereum.wallet === null) {
+    throw new Error("Expected rootState.ethereum.wallet to be set but was null")
+  }
+  const foreignNetwork = String(context.rootState.ethereum.wallet.chainId)
   const expectedNetwork = context.rootState.ethereum.networkId
 
   if (foreignNetwork !== expectedNetwork) {

--- a/src/store/gateway/mapper.ts
+++ b/src/store/gateway/mapper.ts
@@ -29,8 +29,8 @@ export async function loadMapping(context: ActionContext, address: string) {
   const foreignNetwork = String((context.rootState.ethereum.wallet || {}).chainId)
   const expectedNetwork = context.rootState.ethereum.networkId
 
-  console.log(foreignNetwork, expectedNetwork)
   if (foreignNetwork !== expectedNetwork) {
+    console.warn(`Expected network ${expectedNetwork} but wallet network is ${foreignNetwork}.`)
     // fail silently. UI will pickup the state and let user know
     return
   }
@@ -81,7 +81,7 @@ export async function createMapping(context: ActionContext, privateKey: string) 
     idFromPrivateKey(privateKey, context.rootState.plasma.chainId)
 
   state.requireMapping = false
-  console.log("caller", caller)
+  log("caller", caller)
 
   const { address, client } = createDefaultClient(
     CryptoUtils.Uint8ArrayToB64(plasmaId.privateKey),

--- a/src/views/Analytics.vue
+++ b/src/views/Analytics.vue
@@ -140,8 +140,9 @@ export default class Analytics extends Vue {
         autoSkip: true,
       }
     }
-
+    // @ts-ignore 
     const pieChart = new Chart(ctx, config)
+    // @ts-ignore 
     const barChart = new Chart(ctx2, config2)
 
   }


### PR DESCRIPTION
Currently we display a warning at the top of the dashboard if the user has MetaMask connected to a different network than we expect, this should also be caught and prevented on login, don't let the user sign in with MetaMask until they select the correct network.