### PR TITLE
Stake button always gets pushed off the bottom of the page

### DIFF
--- a/src/dpos/views/ValidatorDetail.vue
+++ b/src/dpos/views/ValidatorDetail.vue
@@ -258,4 +258,7 @@ main.validator {
     }
   }
 }
+.button-container {
+  position:inherit  !important;
+}
 </style>


### PR DESCRIPTION
Login, go to the validator list, select a validator. On the validator details page the Stake button will at first appear right under the validator details, but then it'll jump to the bottom of the page causing the vertical scrollbar to appear.

Need to fix this jumping, the stake button should just stay directly under the validator details section, it should be jumping around.