### PR TITLE
Add support for Binance Chain wallet

### DIFF
--- a/src/store/ethereum/index.ts
+++ b/src/store/ethereum/index.ts
@@ -287,7 +287,7 @@ export async function approve(context: ActionContext, payload: Transfer) {
       })
     return result
   } catch (error) {
-    if (isBCWallet(context.rootState.ethereum.wallet!) &&
+    if (isBCWallet(context.rootState.ethereum.wallet) &&
       error.message.includes("Failed to subscribe to new newBlockHeaders to confirm the transaction receipts")) {
       // XXX when it fails it doesnt return the transaction hash
       return ""
@@ -311,7 +311,6 @@ export async function transfer(
     erc20Contracts.get(symbol),
     "Contract not initialized",
   )
-  debugger
   const tx = await contract.methods
     .transfer(to, weiAmount.toString())
     // @ts-ignore

--- a/src/store/ethereum/index.ts
+++ b/src/store/ethereum/index.ts
@@ -33,7 +33,7 @@ import { feedbackModule } from "@/feedback/store"
 import { timer, Subscription } from "rxjs"
 import { i18n } from "@/i18n"
 import { WalletConnectAdapter } from "./wallets/walletconnect"
-import { BinanceChainWalletAdapter, isBCWallet } from "./wallets/binance"
+import { BinanceChainWalletAdapter, isBCWallet, BSC_SAFE_BLOCK_WAIT_TIME_MS } from "./wallets/binance"
 
 declare type ActionContext = BareActionContext<EthereumState, HasEthereumState>
 
@@ -90,7 +90,7 @@ const initialState: EthereumState = {
   gatewayVersions: {
     main: 1,
     loom: 1,
-  }
+  },
 }
 
 // web3 instance
@@ -289,6 +289,7 @@ export async function approve(context: ActionContext, payload: Transfer) {
   } catch (error) {
     if (isBCWallet(context.rootState.ethereum.wallet) &&
       error.message.includes("Failed to subscribe to new newBlockHeaders to confirm the transaction receipts")) {
+      await new Promise((resolve) => setTimeout(resolve, BSC_SAFE_BLOCK_WAIT_TIME_MS))
       // XXX when it fails it doesnt return the transaction hash
       return ""
     } else {

--- a/src/store/ethereum/wallets/binance.ts
+++ b/src/store/ethereum/wallets/binance.ts
@@ -77,18 +77,19 @@ async function changeAccounts(accounts: string[]) {
   }
 }
 
-
 /**
  * https://github.com/loomnetwork/dashboard/issues/1421
  * NOTE: based on ethers 4.0.47!
  */
 function patchSigner(signer: ethers.Signer) {
-  const patch = (message: ethers.utils.Arrayish) => {
+  const patch = async (message: ethers.utils.Arrayish) => {
     const data = ((typeof (message) === "string") ? ethers.utils.toUtf8Bytes(message) : message)
-    return signer.getAddress().then((address) => {
-      const provider: any = signer.provider
-      return provider.bnbSign(address.toLowerCase(), ethers.utils.hexlify(data))
-    })
+    const address = await signer.getAddress()
+    // @ts-ignore
+    return signer.provider._web3Provider.bnbSign(address, ethers.utils.hexlify(data))
+      .then((result) => result.signature)
+      .catch((result) => { throw new Error("Biance wallet: " + result.error) })
+
   }
   signer.signMessage = patch
   return signer

--- a/src/store/ethereum/wallets/binance.ts
+++ b/src/store/ethereum/wallets/binance.ts
@@ -5,6 +5,8 @@ import { ethers } from "ethers"
 import { IWalletProvider, WalletType } from "../types"
 import { ethereumModule } from ".."
 
+export const BSC_SAFE_BLOCK_WAIT_TIME_MS = 15000
+
 export const BinanceChainWalletAdapter: WalletType = {
   id: "binance",
   name: "BinanceChain",
@@ -98,6 +100,5 @@ function patchSigner(signer: ethers.Signer) {
 }
 
 export function isBCWallet(wallet: IWalletProvider | null) {
-  debugger
   return wallet != null && wallet.web3.currentProvider.isBCWallet
 }

--- a/src/store/ethereum/wallets/binance.ts
+++ b/src/store/ethereum/wallets/binance.ts
@@ -46,6 +46,8 @@ export const BinanceChainWalletAdapter: WalletType = {
       changeAccounts(accounts).catch((err) => console.error(err))
     })
 
+    bc.isBCWallet = true
+
     const signer = getMetamaskSigner(bc)
 
     return {
@@ -93,4 +95,8 @@ function patchSigner(signer: ethers.Signer) {
   }
   signer.signMessage = patch
   return signer
+}
+
+export function isBCWallet(wallet: IWalletProvider) {
+  return wallet.web3._provider.isBCWallet
 }

--- a/src/store/ethereum/wallets/binance.ts
+++ b/src/store/ethereum/wallets/binance.ts
@@ -88,15 +88,16 @@ function patchSigner(signer: ethers.Signer) {
     const data = ((typeof (message) === "string") ? ethers.utils.toUtf8Bytes(message) : message)
     const address = await signer.getAddress()
     // @ts-ignore
-    return signer.provider._web3Provider.bnbSign(address, ethers.utils.hexlify(data))
+    return signer.provider.provider.bnbSign(address, ethers.utils.hexlify(data))
       .then((result) => result.signature)
-      .catch((result) => { throw new Error("Biance wallet: " + result.error) })
+      .catch((result) => { throw new Error(`Binance wallet bnbSign failed: ${result.error}`) })
 
   }
   signer.signMessage = patch
   return signer
 }
 
-export function isBCWallet(wallet: IWalletProvider) {
-  return wallet.web3._provider.isBCWallet
+export function isBCWallet(wallet: IWalletProvider | null) {
+  debugger
+  return wallet != null && wallet.web3.currentProvider.isBCWallet
 }

--- a/src/store/gateway/ethereum.ts
+++ b/src/store/gateway/ethereum.ts
@@ -386,7 +386,7 @@ export async function ethereumDeposit(context: ActionContext, funds: Funds) {
       } catch (err) {
         let sendToSentry = true
         // NOTE remove this when BSC supports websocket
-        if (isBCWallet(context.rootState.ethereum.wallet!) &&
+        if (isBCWallet(context.rootState.ethereum.wallet) &&
           err.message.includes("Failed to subscribe to new newBlockHeaders to confirm the transaction receipts")) {
           fb.showSuccess(i18n.t("components.gateway.deposit.confirmed").toString())
           sendToSentry = false
@@ -480,7 +480,7 @@ export async function ethereumWithdraw(context: ActionContext, token_: string) {
   } catch (err) {
     let sendToSentry = true
     // NOTE remove this when BSC supports websocket
-    if (isBCWallet(context.rootState.ethereum.wallet!) &&
+    if (isBCWallet(context.rootState.ethereum.wallet) &&
       err.message.includes("Failed to subscribe to new newBlockHeaders to confirm the transaction receipts")) {
       fb.showSuccess(i18n.t("feedback_msg.success.transaction_success").toString())
       sendToSentry = false

--- a/src/store/gateway/ethereum.ts
+++ b/src/store/gateway/ethereum.ts
@@ -28,6 +28,8 @@ import { ValidatorManagerContract } from "./contracts/ValidatorManagerContract"
 import { gatewayModule } from "./index"
 import { ActionContext, WithdrawalReceiptsV2 } from "./types"
 
+import { isBCWallet } from "../ethereum/wallets/binance"
+
 const log = debug("dash.gateway.ethereum")
 
 /**
@@ -40,7 +42,7 @@ interface EthereumGatewayAdapter {
 
   deposit(amount: BN, address: string)
   withdraw(receipt: IWithdrawalReceipt)
-  
+
 }
 
 class ERC20GatewayAdapter implements EthereumGatewayAdapter {
@@ -380,27 +382,35 @@ export async function ethereumDeposit(context: ActionContext, funds: Funds) {
           funds.weiAmount,
           context.rootState.ethereum.address,
         )
-        fb.showLoadingBar(false)
         fb.showSuccess(i18n.t("components.gateway.deposit.confirmed").toString())
       } catch (err) {
-        fb.showLoadingBar(false)
-        if ("imToken" in window) {
+        let sendToSentry = true
+        // NOTE remove this when BSC supports websocket
+        if (isBCWallet(context.rootState.ethereum.wallet!) &&
+          err.message.includes("Failed to subscribe to new newBlockHeaders to confirm the transaction receipts")) {
+          fb.showSuccess(i18n.t("components.gateway.deposit.confirmed").toString())
+          sendToSentry = false
+        } else if ("imToken" in window) {
           console.log("imToken error", err)
           fb.showInfo(i18n.t("feedback_msg.info.please_track_transaction").toString())
         } else {
           console.error(err)
           fb.showError(i18n.t("components.gateway.deposit.failure").toString())
         }
-        Sentry.withScope((scope) => {
-          scope.setExtra("ethereumDeposit", {
-            funds: JSON.stringify({
-              chain,
-              symbol,
-              amount: weiAmount.toString(),
-            }),
+        if (sendToSentry) {
+          Sentry.withScope((scope) => {
+            scope.setExtra("ethereumDeposit", {
+              funds: JSON.stringify({
+                chain,
+                symbol,
+                amount: weiAmount.toString(),
+              }),
+            })
+            Sentry.captureException(err)
           })
-          Sentry.captureException(err)
-        })
+        }
+      } finally {
+        fb.showLoadingBar(false)
       }
     },
   })
@@ -468,29 +478,37 @@ export async function ethereumWithdraw(context: ActionContext, token_: string) {
     ethereumModule.setUserData({ pendingWithdrawal: true })
     fb.showSuccess(i18n.t("feedback_msg.success.transaction_success").toString())
   } catch (err) {
-    // imToken throws even if transaction succeeds
-    ethereumModule.setUserData({ pendingWithdrawal: false })
-    if ("imToken" in window) {
+    let sendToSentry = true
+    // NOTE remove this when BSC supports websocket
+    if (isBCWallet(context.rootState.ethereum.wallet!) &&
+      err.message.includes("Failed to subscribe to new newBlockHeaders to confirm the transaction receipts")) {
+      fb.showSuccess(i18n.t("feedback_msg.success.transaction_success").toString())
+      sendToSentry = false
+    } else if ("imToken" in window) {
+      // imToken throws even if transaction succeeds
       console.log("imToken error", err, err.hash, "x", err.transactionHash)
     } else {
-      console.log(err)
+      console.error(err)
       fb.showError(i18n.t("feedback_msg.error.withdraw_failed").toString())
     }
-    Sentry.withScope((scope) => {
-      scope.setExtra("ethereumWithdraw", {
-        receipt: JSON.stringify({
-          tokenOwner: receipt.tokenOwner.local.toString(),
-          tokenContract: receipt.tokenContract!.local.toString(),
-          tokenId: (receipt.tokenId || "").toString(),
-          tokenAmount: receipt.tokenAmount!.toString(),
-          signatures: receipt.oracleSignature,
-        }),
+    if (sendToSentry) {
+      Sentry.withScope((scope) => {
+        scope.setExtra("ethereumWithdraw", {
+          receipt: JSON.stringify({
+            tokenOwner: receipt.tokenOwner.local.toString(),
+            tokenContract: receipt.tokenContract!.local.toString(),
+            tokenId: (receipt.tokenId || "").toString(),
+            tokenAmount: receipt.tokenAmount!.toString(),
+            signatures: receipt.oracleSignature,
+          }),
+        })
+        Sentry.captureException(err)
       })
-      Sentry.captureException(err)
-    })
+    }
+  } finally {
+    ethereumModule.setUserData({ pendingWithdrawal: false })
+    fb.showLoadingBar(false)
   }
-  ethereumModule.setUserData({ pendingWithdrawal: false })
-  fb.showLoadingBar(false)
 }
 
 export async function refreshEthereumHistory(context: ActionContext) {
@@ -504,7 +522,7 @@ export async function refreshEthereumHistory(context: ActionContext) {
     switch (symbol) {
       case PlasmaTokenKind.ETH:
         if (mainGateway !== null) {
-          return logEvents(address, mainGateway, symbol, "ETHReceived", "TokenWithdrawn") 
+          return logEvents(address, mainGateway, symbol, "ETHReceived", "TokenWithdrawn")
         }
       case PlasmaTokenKind.LOOMCOIN:
         return logEvents(address, loomGateway, symbol, "LoomCoinReceived", "TokenWithdrawn")


### PR DESCRIPTION
The Binance Chain wallet API mimics MetaMask but has some quirks with the `personal_sign` web3 function we rely on for account mappings, specifically it doesn't implement `personal_sign` and instead provides a custom `bnbSign` function on the wallet instance. The problem is loom-js relies on an ethers.js signer that wraps the web3 provider, ethers.js doesn't know anything about this `bnbSign` function so it doesn't work with Binance Chain wallet. The quickest way to work around this is probably by monkey patching the ethers.js signer to call `bnbSign` instead of `personal_sign`.