### PR TITLE
Set Extdev LOOM Gateway address on BSC Testnet and enable BSC wallets

### DIFF
--- a/src/assets/tokens/ext-dev.binance.tokens.json
+++ b/src/assets/tokens/ext-dev.binance.tokens.json
@@ -3,7 +3,7 @@
     "symbol": "LOOM",
     "name": "Loom",
     "decimals": 18,
-    "ethereum": "0x0000000000000000000000000000000000000000",
+    "ethereum": "0xddb89011821aed4908e8b4b3dbdbd81e9026e9cb",
     "plasma": "0x0e9d499f42dfafe7f0e397f86fee6ab09483f36b"
   }
 ]

--- a/src/config/ext-dev.ts
+++ b/src/config/ext-dev.ts
@@ -41,7 +41,7 @@ export default {
     blockExplorer: "https://testnet.bscscan.com",
     blockExplorerApi: "api-testnet.bscscan.com/api",
     contracts: {
-      loomGateway: "0xdeadbeef",
+      loomGateway: "0x8Fa01da9B68dc0cAE32e12E8daFE9B136EfAbee6",
       mainGateway: ethers.constants.AddressZero // NOTE: generic gateway is not deployed on BSC yet
     },
     gatewayVersions: {
@@ -72,6 +72,6 @@ export default {
     home: false,
   },
   features: {
-    bscWallets: false,
+    bscWallets: true,
   }
 } as DashboardConfig


### PR DESCRIPTION
Reusing the same LOOM BEP20 token contract for `extdev` that was previously deployed to `asia1`.