### PR TITLE
Some config changes don't take effect until page reload

### DIFF
--- a/src/components/ChainSelector.vue
+++ b/src/components/ChainSelector.vue
@@ -15,7 +15,7 @@ export default class ChainSelector extends Vue {
   set env(config: DashboardConfig) {
     console.log("config", config)
     localStorage.setItem("selectedConfig", config.name)
-    dashboardStore.setEnv(config)
+    window.location.reload()
   }
 
   get envs() {
@@ -28,7 +28,9 @@ export default class ChainSelector extends Vue {
 <template>
   <div id="chain-selector" v-if="envs.length > 1">
     <b-form-select v-model="env" size="sm" class="mt-3">
-      <option v-for="env in envs" :value="env" :key="env.name">{{env.name}}</option>
+      <option v-for="env in envs" :value="env" :key="env.name">
+        {{ env.name }}
+      </option>
     </b-form-select>
   </div>
 </template>


### PR DESCRIPTION
There was a `features.bscWallets` setting added to the config in this PR https://github.com/loomnetwork/dashboard/pull/1423
Unfortunately it doesn't look like switching the configuration on the login page has an immediate effect on this particular setting. For example if the dashboard is initially loaded with the `production` config selected then only the Ethereum wallets will be visible initially (`bscWallets === false`), if you then select `dev` from the drop-down the BSC wallets should be displayed immediately... but they do not appear until the page is reloaded.