### PR TITLE
Withdrawal confirmation dialog shouldn't close on focus loss

### DIFF
--- a/src/components/gateway/WithdrawConfirmed.vue
+++ b/src/components/gateway/WithdrawConfirmed.vue
@@ -1,9 +1,12 @@
 <template>
-  <b-modal lazy id="withdraw-confirmed" v-model="visible" :title="title">
+  <b-modal lazy id="withdraw-confirmed" v-model="visible" :title="title" no-close-on-esc no-close-on-backdrop hide-header-close >
     <section v-if="status === 'default'">
       <b-container fluid>
         <div v-if="chain !== 'binance'" class="lead">
-          <p>{{$t('components.gateway.confirm_withdrawal_modal.confirm_withdrawl', {chain,amount, token: this.symbol})}}</p>
+          <p>{{
+            $t('components.gateway.confirm_withdrawal_modal.confirm_withdrawl', 
+              { chain: state.ethereum.genericNetworkName, amount, token: this.symbol })
+          }}</p>
         </div>
         <div v-else>
            <p>Fund withdrawn to Binance</p>

--- a/src/feedback/components/FeedbackAlert.vue
+++ b/src/feedback/components/FeedbackAlert.vue
@@ -1,11 +1,18 @@
 <template>
-  <b-modal v-model="visible"
+  <b-modal
+    v-model="visible"
     :title="$t(title)"
+    :no-close-on-backdrop="isConfirmation"
+    :no-close-on-esc="isConfirmation"
+    :hide-header-close="isConfirmation"
     :hide-footer="hideFooter"
     @ok="handleOk"
-    @hide="close">
-
+    @hide="close"
+  >
     {{ $t(message) }}
+    <template #modal-footer="{ ok }">
+      <b-button variant="primary" @click="ok()"> OK </b-button>
+    </template>
   </b-modal>
 </template>
 <script lang="ts">
@@ -40,6 +47,10 @@ export default class FeedbackAlert extends Vue {
 
   get hideFooter() {
     return this.alert.type === "alert" ? true : false
+  }
+
+  get isConfirmation() {
+    return this.alert.type === "confirmation"
   }
 
   handleOk() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -868,7 +868,7 @@
       "please_track_deposit_approval": "Please track deposit approval the transaction on your wallet.",
       "withdrawal_in_progress": "Withdrawal already in progress.",
       "withdrawal_request_sent": "Withdrawal request sent. Your binance account will receive the funds in a moment.",
-      "please_sign_tx": "Please sign the tx using your wallet."
+      "please_sign_tx": "Please sign the transaction using your wallet."
     },
     "success": {
       "transaction_success": "Transaction sent successfully.",
@@ -892,7 +892,7 @@
         "complete_deposit": "Complete deposit"
       },
       "message": {
-        "please_sign_click": "Please sign click confirm to complete your deposit."
+        "please_sign_click": "Please sign the next transaction using your wallet to complete the deposit."
       }
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -814,7 +814,7 @@
       "please_track_deposit_approval": "Please track deposit approval the transaction on your wallet.",
       "withdrawal_in_progress": "Withdrawal already in progress.",
       "withdrawal_request_sent": "Withdrawal request sent. Your binance account will receive the funds in a moment.",
-      "please_sign_tx": "Please sign the tx using your wallet."
+      "please_sign_tx": "Please sign the transaction using your wallet."
     },
     "success": {
       "transaction_success": "Transaction sent successfully.",
@@ -838,7 +838,7 @@
         "complete_deposit": "Complete deposit"
       },
       "message": {
-        "please_sign_click": "Please sign click confirm to complete your deposit."
+        "please_sign_click": "Please sign the next transaction using your wallet to complete the deposit."
       }
     }
   },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -814,7 +814,7 @@
       "please_track_deposit_approval": "Please track deposit approval the transaction on your wallet.",
       "withdrawal_in_progress": "Withdrawal already in progress.",
       "withdrawal_request_sent": "Withdrawal request sent. Your binance account will receive the funds in a moment.",
-      "please_sign_tx": "Please sign the tx using your wallet."
+      "please_sign_tx": "Please sign the transaction using your wallet."
     },
     "success": {
       "transaction_success": "Transaction sent successfully.",
@@ -838,7 +838,7 @@
         "complete_deposit": "Complete deposit"
       },
       "message": {
-        "please_sign_click": "Please sign click confirm to complete your deposit."
+        "please_sign_click": "Please sign the next transaction using your wallet to complete the deposit."
       }
     }
   },

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -814,7 +814,7 @@
       "please_track_deposit_approval": "Please track deposit approval the transaction on your wallet.",
       "withdrawal_in_progress": "Withdrawal already in progress.",
       "withdrawal_request_sent": "Withdrawal request sent. Your binance account will receive the funds in a moment.",
-      "please_sign_tx": "Please sign the tx using your wallet."
+      "please_sign_tx": "Please sign the transaction using your wallet."
     },
     "success": {
       "transaction_success": "Transaction sent successfully.",
@@ -838,7 +838,7 @@
         "complete_deposit": "Complete deposit"
       },
       "message": {
-        "please_sign_click": "Please sign click confirm to complete your deposit."
+        "please_sign_click": "Please sign the next transaction using your wallet to complete the deposit."
       }
     }
   },


### PR DESCRIPTION
Clicking outside this dialog makes it disappear, leaving a withdrawal half-done, bad UX.
![image](https://user-images.githubusercontent.com/233003/116369818-ff99cc80-a833-11eb-921c-a77762e35efa.png)
