### PR TITLE
Make the "wrong network" dialog a bit clearer

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -581,7 +581,7 @@
       "sign_wallet": "Using your wallet, sign the message to confirm your {network} identity. (No gas required)",
       "already_mapped": " Your selected accout is already mapped. Please select new account.",
       "your_wallet_connected_to": "Your wallet is connected to {network}.",
-      "please_change_to": "Please change to {network}."
+      "please_change_to": "Please connect it to {network}, and then press the button below."
     },
     "loading_spinner": {
       "please_be_patient_loomy_is": "Please be patient, Loomy is on it!",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -527,7 +527,7 @@
       "sign_wallet": "Using your wallet, sign the message to confirm your {network} identity. (No gas required)",
       "already_mapped": " Your selected accout is already mapped. Please select new account.",
       "your_wallet_connected_to": "Your wallet is connected to {network}.",
-      "please_change_to": "Please change to {network}."
+      "please_change_to": "Please connect it to {network}, and then press the button below."
     },
     "loading_spinner": {
       "please_be_patient_loomy_is": "Please be patient, Loomy is on it!",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -527,7 +527,7 @@
       "sign_wallet": "Using your wallet, sign the message to confirm your {network} identity. (No gas required)",
       "already_mapped": "選択したアカウントはすでにマッピング済みです。新しいアカウントを選択して下さい。",
       "your_wallet_connected_to": "Your wallet is connected to {network}.",
-      "please_change_to": "Please change to {network}."
+      "please_change_to": "Please connect it to {network}, and then press the button below."
     },
     "loading_spinner": {
       "please_be_patient_loomy_is": "Loomyが頑張ってロード中！少々お待ちください。",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -527,7 +527,7 @@
       "sign_wallet": "Using your wallet, sign the message to confirm your {network} identity. (No gas required)",
       "already_mapped": "당신의 선택된 계정은 이미 매핑되어 있습니다. 새로운 계정을 선택하세요.",
       "your_wallet_connected_to": "당신의 지갑은 {network}에 이미 연결되어 있습니다.",
-      "please_change_to": "{network}로 변경해주세요."
+      "please_change_to": "Please connect it to {network}, and then press the button below."
     },
     "loading_spinner": {
       "please_be_patient_loomy_is": "잠시만 기다려주세요, Loomy가 처리 중입니다!",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -527,7 +527,7 @@
       "sign_wallet": "Using your wallet, sign the message to confirm your {network} identity. (No gas required)",
       "already_mapped": " Your selected accout is already mapped. Please select new account.",
       "your_wallet_connected_to": "Your wallet is connected to {network}.",
-      "please_change_to": "Please change to {network}."
+      "please_change_to": "Please connect it to {network}, and then press the button below."
     },
     "loading_spinner": {
       "please_be_patient_loomy_is": "Please be patient, Loomy is on it!",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -527,7 +527,7 @@
       "sign_wallet": "Using your wallet, sign the message to confirm your {network} identity. (No gas required)",
       "already_mapped": " 你选择的账户已映射。请选择新帐户。",
       "your_wallet_connected_to": "你的钱包已连接到 {network}。",
-      "please_change_to": "请更换到 {network}。"
+      "please_change_to": "Please connect it to {network}, and then press the button below."
     },
     "loading_spinner": {
       "please_be_patient_loomy_is": "请耐心等待哟，Loomy 正在努力加载！",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/233003/116039033-697b7000-a694-11eb-98b9-a3617ba37543.png)

This dialog that pops up when the user attempts to login while their wallet is connected to a different network than expected should say:

`Your wallet is currently connected to X. Please connect it to Y, and then press the button below.`

That way the page reload is more likely to happen after they fix their wallet.