### PR TITLE
ETH is showing up in the Basechain wallet when connected to BSC

### DIFF
--- a/src/store/plasma/reactions.ts
+++ b/src/store/plasma/reactions.ts
@@ -40,7 +40,9 @@ export function plasmaReactions(store: Store<DashboardState>) {
       }
       await createPlasmaWeb3(store)
       await resetLoomContract(store)
-      await resetEthContract(store)
+      if (store.state.ethereum.genericNetworkName === "Ethereum") {
+        await resetEthContract(store)
+      }
     },
   )
 


### PR DESCRIPTION
**Describe the bug**
ETH is showing up in the Basechain wallet when connected to BSC

**To Reproduce**
Steps to reproduce the behavior:
1. Go to https://dev-dashboard.dappchains.com
2. Connect to BSC Testnet

**Screenshots**
![image](https://user-images.githubusercontent.com/23660413/114262523-0c2dc080-99fe-11eb-85e4-7c70573ddacb.png)


**Environment:**
 - Chrome/Metamask


**Additional context**

0x2e8d2AA6AD610a111dB872F344D90B6a650A80de
