### PR TITLE
Review MetaMask wallet integration for API changes

### DIFF
--- a/src/store/ethereum/index.ts
+++ b/src/store/ethereum/index.ts
@@ -378,6 +378,7 @@ export function initERC20(context: ActionContext, symbol: string) {
     refresh,
   )
 
+  // For the deprectaion waring see https://github.com/MetaMask/metamask-extension/issues/9301#issuecomment-680955280
   send.on("data", refresh)
   receive.on("data", refresh)
 

--- a/src/store/ethereum/wallets/metamask.ts
+++ b/src/store/ethereum/wallets/metamask.ts
@@ -61,7 +61,7 @@ async function getCurrentApi(): Promise<provider> {
   // @ts-ignore
   const ethereum: any = window.ethereum
   try {
-    await ethereum.enable()
+    await ethereum.request({ method: "eth_requestAccounts" })
   } catch (err) {
     Sentry.captureException(err)
     feedbackModule.endTask()


### PR DESCRIPTION
Seeing this in the console when loading the staking dashboard:
```
MetaMask: The event 'data' is deprecated and will be removed in the future. Use 'message' instead.
```