### PR TITLE
Add tooltips for Ethereum wallets on the login page

### DIFF
--- a/src/components/WalletsTooltipsBSC.vue
+++ b/src/components/WalletsTooltipsBSC.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <b-popover
+      class="popover"
+      target="bsc-binance-wallet"
+      title="Binance Chain Wallet"
+      triggers="hover"
+    >
+      <p>This wallet also supports <strong>Ledger</strong>.</p>
+      <p>
+        If you want to use a Ledger open the Binance Chain Wallet extension and
+        select
+        <strong>Hardware Wallet</strong> from the menu, then follow the steps to
+        setup your device for use with Binance Chain Wallet.
+      </p>
+      <img
+        style="width: 100%"
+        src="../assets/binance-wallet-ledger.png"
+        alt="Screenshot of setting up Ledger in Binance Chain Wallet"
+      />
+    </b-popover>
+    <b-popover
+      class="popover"
+      target="bsc-metamask-wallet"
+      title="Metamask Wallet"
+      triggers="hover"
+    >
+      <p>
+        This wallet also supports <strong>Ledger</strong> and
+        <strong>Trezor</strong>.
+      </p>
+      <p>
+        If you want to use a Ledger or Trezor open the Metamask extension and
+        select
+        <strong>Connect Hardware Wallet</strong> from the menu, then follow the
+        steps to setup your device for use with Metamask.
+      </p>
+      <img
+        style="width: 100%"
+        src="@/assets/metamask-hardware-screencap.png"
+        alt="Screenshot of setting up hardware wallet in Metamask"
+      />
+    </b-popover>
+    <b-popover
+      class="popover"
+      target="bsc-walletconnect"
+      title="WalletConnect Protocol"
+      triggers="hover"
+    >
+      WalletConnect supports many <strong>iOS</strong> and
+      <strong>Android</strong> wallets. It's easy to use and there's nothing to
+      install, just scan a QR code to connect.
+    </b-popover>
+  </div>
+</template>

--- a/src/components/WalletsTooltipsEthereum.vue
+++ b/src/components/WalletsTooltipsEthereum.vue
@@ -1,0 +1,49 @@
+<template>
+  <div>
+    <b-popover
+      class="popover"
+      target="metamask-button"
+      title="Metamask"
+      triggers="hover"
+    >
+      <p>
+        This wallet also supports <strong>Ledger</strong> and
+        <strong>Trezor</strong>.
+      </p>
+      <p>
+        If you want to use a Ledger or Trezor open the Metamask extension and
+        select
+        <strong>Connect Hardware Wallet</strong> from the menu, then follow the
+        steps to setup your device for use with Metamask.
+      </p>
+      <img
+        style="width: 100%"
+        src="@/assets/metamask-hardware-screencap.png"
+        alt="Screenshot of setting up hardware wallet in Metamask"
+      />
+    </b-popover>
+    <b-popover
+      class="popover"
+      target="eth-walletconnect-button"
+      title="WalletConnect Protocol"
+      triggers="hover"
+    >
+      WalletConnect supports many <strong>iOS</strong> and
+      <strong>Android</strong> wallets. It's easy to use and there's nothing to
+      install, just scan a QR code to connect.
+    </b-popover>
+    <b-popover
+      class="popover"
+      target="eth-walletlink-button"
+      title="WalletLink/Coinbase"
+      triggers="hover"
+    >
+      For the time being WalletLink only supports Coinbase Wallet mobile app.
+    </b-popover>
+  </div>
+</template>
+<style scoped>
+.popover-body img {
+  width: 100%;
+}
+</style>

--- a/src/components/WalletsTooltipsEthereum.vue
+++ b/src/components/WalletsTooltipsEthereum.vue
@@ -30,12 +30,15 @@
     >
       WalletConnect supports many <strong>iOS</strong> and
       <strong>Android</strong> wallets. It's easy to use and there's nothing to
-      install, just scan a QR code to connect.
+      install, just scan a QR code to connect. See the
+      <a href="https://walletconnect.org/wallets" target="_blank"
+        >list of mobile wallets supported by WalletConnect</a
+      >
     </b-popover>
     <b-popover
       class="popover"
       target="eth-walletlink-button"
-      title="WalletLink/Coinbase"
+      title="WalletLink Protocol"
       triggers="hover"
     >
       For the time being WalletLink only supports Coinbase Wallet mobile app.

--- a/src/views/FirstPage.vue
+++ b/src/views/FirstPage.vue
@@ -151,44 +151,6 @@
                           </div>
                         </b-card>
                       </div>
-                      <div class="col-sm-12">
-                        <b-card
-                          id="ledger-button"
-                          class="wallet-selection-card text-center mb-3"
-                          @click="
-                            $root.$emit(
-                              'bv::show::modal',
-                              'metmask-hardware-wizard'
-                            )
-                          "
-                        >
-                          <div>
-                            <img src="@/assets/ledger_logo.svg" />
-                            <span>{{
-                              $t("views.first_page.wallets.ledger_via_metamask")
-                            }}</span>
-                          </div>
-                        </b-card>
-                      </div>
-                      <div class="col-sm-12 mb-3">
-                        <b-card
-                          id="trezor-button"
-                          class="wallet-selection-card text-center"
-                          @click="
-                            $root.$emit(
-                              'bv::show::modal',
-                              'metmask-hardware-wizard'
-                            )
-                          "
-                        >
-                          <div>
-                            <img :src="wallets.get('metamask').logo" />
-                            <span>{{
-                              $t("views.first_page.wallets.trezor_via_metamask")
-                            }}</span>
-                          </div>
-                        </b-card>
-                      </div>
                       <div class="col-sm-12 mb-3">
                         <b-card
                           id="eth-walletconnect-button"
@@ -341,31 +303,6 @@
                 >{{ $t("button.submit") }}</b-button
               >
             </div>
-          </b-modal>
-
-          <b-modal
-            id="metmask-hardware-wizard"
-            :title="
-              $t('components.modals.hardware_wallet_modal.hardware_wallet')
-            "
-          >
-            <div>
-              <div class="wizard-img-container mb-3">
-                <img
-                  class="wizard-img"
-                  src="../assets/metamask-hardware-screencap.png"
-                  alt
-                />
-              </div>
-              <p>{{ $t("messages.metamask_hardware_wizard") }}</p>
-            </div>
-            <template slot="modal-footer">
-              <div>
-                <b-btn @click="setWallet('ethereum', 'metamask')">{{
-                  $t("button.next")
-                }}</b-btn>
-              </div>
-            </template>
           </b-modal>
 
           <ChainSelector

--- a/src/views/FirstPage.vue
+++ b/src/views/FirstPage.vue
@@ -116,6 +116,7 @@
                     </div>
                   </div>
                 </b-card-body>
+                <WalletsTooltipsBSC />
               </b-card>
               <!-- Ethereum wallets -->
               <b-card v-once>
@@ -190,6 +191,7 @@
                       </div>
                       <div class="col-sm-12 mb-3">
                         <b-card
+                          id="eth-walletconnect-button"
                           class="wallet-selection-card text-center"
                           @click="setWallet('ethereum', 'walletconnect')"
                         >
@@ -201,6 +203,7 @@
                       </div>
                       <div class="col-sm-12 mb-3">
                         <b-card
+                          id="eth-walletlink-button"
                           class="wallet-selection-card text-center"
                           @click="setWallet('ethereum', 'walletlink')"
                         >
@@ -227,6 +230,7 @@
                     </div>
                   </div>
                 </b-card-body>
+                <WalletsTooltipsEthereum />
               </b-card>
             </b-card-group>
             <template v-if="env">
@@ -363,68 +367,7 @@
               </div>
             </template>
           </b-modal>
-          <b-popover
-            class="popover"
-            target="bsc-binance-wallet"
-            title="Binance Chain Wallet"
-            triggers="hover"
-            v-if="bscWalletsEnabled"
-          >
-            <p>This wallet also supports <strong>Ledger</strong>.</p>
-            <p>
-              If you want to use a Ledger open the Binance Chain Wallet
-              extension and select
-              <strong>Hardware Wallet</strong> from the menu, then follow the
-              steps to setup your device for use with Binance Chain Wallet.
-            </p>
-            <div>
-              <div class="wizard-img-container mb-3">
-                <img
-                  class="wizard-img"
-                  src="../assets/binance-wallet-ledger.png"
-                  alt="Screenshot of setting up Ledger in Binance Chain Wallet"
-                />
-              </div>
-            </div>
-          </b-popover>
-          <b-popover
-            class="popover"
-            target="bsc-metamask-wallet"
-            title="Metamask Wallet"
-            triggers="hover"
-            v-if="bscWalletsEnabled"
-          >
-            <p>
-              This wallet also supports <strong>Ledger</strong> and
-              <strong>Trezor</strong>.
-            </p>
-            <p>
-              If you want to use a Ledger or Trezor open the Metamask extension
-              and select
-              <strong>Connect Hardware Wallet</strong> from the menu, then
-              follow the steps to setup your device for use with Metamask.
-            </p>
-            <div>
-              <div class="wizard-img-container mb-3">
-                <img
-                  class="wizard-img"
-                  src="../assets/metamask-hardware-screencap.png"
-                  alt="Screenshot of setting up hardware wallet in Metamask"
-                />
-              </div>
-            </div>
-          </b-popover>
-          <b-popover
-            class="popover"
-            target="bsc-walletconnect"
-            title="WalletConnect Protocol"
-            triggers="hover"
-            v-if="bscWalletsEnabled"
-          >
-            WalletConnect supports many <strong>iOS</strong> and
-            <strong>Android</strong> wallets. It's easy to use and there's
-            nothing to install, just scan a QR code to connect.
-          </b-popover>
+
           <ChainSelector
             style="width: 250px; margin: 0 auto"
             class="connection-status"
@@ -437,7 +380,9 @@
 
 <script lang="ts">
 import { Vue, Component } from "vue-property-decorator"
-import ChainSelector from "../components/ChainSelector.vue"
+import ChainSelector from "@/components/ChainSelector.vue"
+import WalletsTooltipsBSC from "@/components/WalletsTooltipsBSC.vue"
+import WalletsTooltipsEthereum from "@/components/WalletsTooltipsEthereum.vue"
 
 import { ethereumModule } from "@/store/ethereum"
 import { DashboardState } from "../types"
@@ -455,6 +400,8 @@ import { wallets } from "@/store/ethereum"
 
 @Component({
   components: {
+    WalletsTooltipsBSC,
+    WalletsTooltipsEthereum,
     ChainSelector,
     LoomIcon,
   },
@@ -631,7 +578,7 @@ export default class FirstPage extends Vue {
 
 .popover {
   h3 {
-    color: gray;
+    color: black;
   }
 }
 


### PR DESCRIPTION
The BSC wallets have useful tooltips when you mouse over them. The Ethereum wallets should have some too. Can copy MetaMask and WalletConnect tooltips from the BSC wallets. And the one for WalletLink should just make it obvious you need the Coinbase mobile wallet to use it.