### PR TITLE
Disconnect previous WalletConnect session on login page

### DIFF
--- a/src/store/ethereum/index.ts
+++ b/src/store/ethereum/index.ts
@@ -175,7 +175,7 @@ async function setWalletType(context: ActionContext, walletType: string) {
     await wallet
       .createProvider(context.state)
       .then((provider) => {
-        walletDisconnectBeforeUnload(provider)
+        disconnectWalletBeforeUnload(provider)
         return setProvider(context, provider)
       })
       .catch((error) => {
@@ -186,7 +186,7 @@ async function setWalletType(context: ActionContext, walletType: string) {
   }
 }
 
-function walletDisconnectBeforeUnload(wallet) {
+function disconnectWalletBeforeUnload(wallet) {
   const listener = (e: BeforeUnloadEvent) => {
     e.preventDefault()
     wallet.disconnect()

--- a/src/store/ethereum/index.ts
+++ b/src/store/ethereum/index.ts
@@ -174,13 +174,25 @@ async function setWalletType(context: ActionContext, walletType: string) {
 
     await wallet
       .createProvider(context.state)
-      .then(async (provider) => await setProvider(context, provider))
+      .then((provider) => {
+        walletDisconnectBeforeUnload(provider)
+        return setProvider(context, provider)
+      })
       .catch((error) => {
         Sentry.captureException(error)
         console.error(error)
         feedbackModule.showError(i18n.t("feedback_msg.error.connect_wallet_prob").toString())
       })
   }
+}
+
+function walletDisconnectBeforeUnload(wallet) {
+  const listener = (e: BeforeUnloadEvent) => {
+    e.preventDefault()
+    wallet.disconnect()
+    window.removeEventListener("beforeunload", listener)
+  }
+  window.addEventListener("beforeunload", listener)
 }
 
 async function setProvider(context: ActionContext, p: IWalletProvider) {

--- a/src/store/ethereum/wallets/walletconnect.ts
+++ b/src/store/ethereum/wallets/walletconnect.ts
@@ -23,10 +23,12 @@ export const WalletConnectAdapter: WalletType = {
     if (config.genericNetworkName === "Ethereum") {
       opts.infuraId = `${process.env.INFURA_PROJECT_ID}`
     } else {
-      opts.chainId = parseInt(config.networkId)
+      opts.chainId = parseInt(config.networkId, 10)
       opts.rpc = { [opts.chainId]: config.endpoint }
     }
+    localStorage.removeItem("walletconnect")
     const wcProvider = new WalletConnectProvider(opts)
+
     wcProvider.on(
       "chainChanged",
       (chainId: string) => {

--- a/src/store/ethereum/wallets/walletconnect.ts
+++ b/src/store/ethereum/wallets/walletconnect.ts
@@ -26,6 +26,7 @@ export const WalletConnectAdapter: WalletType = {
       opts.chainId = parseInt(config.networkId, 10)
       opts.rpc = { [opts.chainId]: config.endpoint }
     }
+    // clear our previous session so user is prompted to scan QR code
     localStorage.removeItem("walletconnect")
     const wcProvider = new WalletConnectProvider(opts)
 


### PR DESCRIPTION
Here's an example scenario:
1. User selects WalletConnect from the login page, scans QR code to connect
2. User reloads the dashboard
3. User selects WalletConnect from the login page, is automatically connected because the previous session was reused

Reusing the session in step 3 can be confusing, the user might want to use a different account but they're automatically connected using the previous account. I think it's best to always clear out the old session so the user is prompted to scan the QR code (which gives them the ability to pick the account they want to use). 