### PR TITLE
Add ability to view all delegations on the My Account page when logged in as a validator

### DIFF
--- a/src/components/gateway/WithdrawConfirmed.vue
+++ b/src/components/gateway/WithdrawConfirmed.vue
@@ -77,7 +77,8 @@ export default class WithdrawConfirmed extends Vue {
   }
 
   get title() {
-    return status === "error" ? this.$t("components.gateway.confirm_withdrawal_modal.status_failed") : this.$t("components.gateway.confirm_withdrawal_modal.status_confirmed")
+    return status === "error" ? this.$t("components.gateway.confirm_withdrawal_modal.status_failed")
+      : this.$t("components.gateway.confirm_withdrawal_modal.status_confirmed")
   }
 
   get visible() {

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -37,16 +37,16 @@
             :per-page="perPage"
             :current-page="currentPage"
           >
-            <template scope="data" slot="delegator">
+            <template slot-scope="data" slot="delegator">
               {{ data.item.delegator.local.toString() | loomAddress }}
             </template>
-            <template scope="data" slot="index">
+            <template slot-scope="data" slot="index">
               {{ data.item.index }}
             </template>
-            <template scope="data" slot="amount">
+            <template slot-scope="data" slot="amount">
               {{ data.item.amount | tokenAmount(18, 3) }} LOOM
             </template>
-            <template scope="data" slot="lockTime">
+            <template slot-scope="data" slot="lockTime">
               <span v-if="data.item.lockTime > today">
                 {{ data.item.lockTime | dateWithoutTime }}
               </span>

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -73,9 +73,7 @@ import { Vue, Component, Prop } from "vue-property-decorator"
 import { Delegation, HasDPOSState, Validator } from "@/dpos/store/types"
 import { ZERO } from "@/utils"
 
-@Component({
-  components: {},
-})
+@Component
 export default class OtherDelegations extends Vue {
   @Prop({ required: true }) validator!: Validator
 
@@ -165,6 +163,7 @@ dl {
   }
   dt {
     font-weight: normal;
+    text-align: left;
   }
   dd {
     font-weight: 500;

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -106,7 +106,7 @@ export default class OtherDelegations extends Vue {
   }
 
   get today() {
-    return  Date.now()/1000
+    return  Date.now() / 1000
   }
 
   get tableFields() {

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -47,10 +47,12 @@
               {{ data.item.amount | tokenAmount(18, 3) }} LOOM
             </template>
             <template scope="data" slot="lockTime">
-              <span v-if="data.item.lockTime != 0">
-                {{ data.item.lockTime | dateWithoutTime }}</span
-              >
-              <span v-else> {{ $t("views.validator_detail.unlocked") }}</span>
+              <span v-if="data.item.lockTime > today">
+                {{ data.item.lockTime | dateWithoutTime }}
+              </span>
+              <span v-else>
+                {{ $t("views.validator_detail.unlocked") }}
+              </span>
             </template>
           </b-table>
           <b-pagination
@@ -101,6 +103,10 @@ export default class OtherDelegations extends Vue {
       this.$t("components.modals.faucet_delegate_modal.six_months").toString(),
       this.$t("components.modals.faucet_delegate_modal.one_year").toString(),
     ]
+  }
+
+  get today() {
+    return  Date.now()/1000
   }
 
   get tableFields() {

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -66,7 +66,7 @@ import { ZERO } from "@/utils"
 @Component({
   components: {},
 })
-export default class ValidationDelegations extends Vue {
+export default class OtherDelegations extends Vue {
   zero = ZERO
 
   @Prop({ required: true }) validator!: Validator

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -5,7 +5,7 @@
       {{ totalStaked | tokenAmount(18, 3) }} LOOM
     </h6>
     <div role="tablist" v-if="delegations.length">
-      <div v-for="(tier, index) in locktimeTiers">
+      <div v-for="(tier, index) in locktimeTiers" :key="'lt_'+index">
         <b-button
           block
           aria-controls="collapse-4"
@@ -16,7 +16,7 @@
         >
           <dl>
             <dt>
-              {{ $t("components.other_delegations.lock_time") }} {{ tier }}
+              {{ $t("components.other_delegations.lock_time") }}: {{ tier }}
             </dt>
             <dd>
               {{ getSumDelegations(getDelegationsTier(index)) | tokenAmount(18, 3) }}

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -1,6 +1,9 @@
 <template>
-  <div class="validation-delegations">
-    <h6>Total stake: {{ totalStaked | tokenAmount(18, 0) }} LOOM</h6>
+  <div class="validation-delegations py-2">
+    <h6>
+      {{ $t("components.other_delegations.total_staked") }}:
+      {{ totalStaked | tokenAmount(18, 0) }} LOOM
+    </h6>
     <div role="tablist" v-if="delegations.length">
       <div v-for="(tier, index) in locktimeTiers">
         <b-button
@@ -12,7 +15,9 @@
           v-b-toggle="'accordion-' + currentTier"
         >
           <dl>
-            <dt>Locktime {{ tier }}</dt>
+            <dt>
+              {{ $t("components.other_delegations.lock_time") }} {{ tier }}
+            </dt>
             <dd>
               {{ getSumDelegations(getDelegationsTier(index)) | tokenAmount }}
               LOOM
@@ -33,7 +38,7 @@
             :current-page="currentPage"
           >
             <template scope="data" slot="delegator">
-              loom{{ data.item.delegator.local.toString().substring(2) }}
+              {{ data.item.delegator.local.toString() | loomAddress }}
             </template>
             <template scope="data" slot="index">
               {{ data.item.index }}
@@ -72,12 +77,12 @@ import { ZERO } from "@/utils"
   components: {},
 })
 export default class OtherDelegations extends Vue {
+  @Prop({ required: true }) validator!: Validator
+
   zero = ZERO
   currentTier = 5
   perPage = 10
   currentPage = 1
-
-  @Prop({ required: true }) validator!: Validator
 
   get state(): HasDPOSState {
     return this.$store.state
@@ -94,11 +99,34 @@ export default class OtherDelegations extends Vue {
   get locktimeTiers() {
     return [
       this.$t("components.modals.faucet_delegate_modal.two_weeks").toString(),
-      this.$t(
-        "components.modals.faucet_delegate_modal.three_months"
-      ).toString(),
+      this.$t("components.modals.faucet_delegate_modal.three_months").toString(),
       this.$t("components.modals.faucet_delegate_modal.six_months").toString(),
       this.$t("components.modals.faucet_delegate_modal.one_year").toString(),
+    ]
+  }
+
+  get tableFields() {
+    return [
+      {
+        key: "delegator",
+        label: this.$t("components.other_delegations.delegator").toString(),
+      },
+      {
+        key: "index",
+        label: this.$t("components.other_delegations.delegation_index").toString(),
+      },
+      {
+        key: "amount",
+        label: this.$t("components.other_delegations.amount_staked").toString(),
+      },
+      {
+        key: "lockTimeTier",
+        label: this.$t("components.other_delegations.tier").toString(),
+      },
+      {
+        key: "lockTime",
+        label: this.$t("components.other_delegations.unlock_time").toString(),
+      },
     ]
   }
 
@@ -118,16 +146,7 @@ export default class OtherDelegations extends Vue {
     this.currentTier = selectedTier
     this.currentPage = 1
   }
-
-  tableFields = [
-    { key: "delegator", label: "Delegator" },
-    { key: "index", label: "Delegation index" },
-    { key: "amount", label: "Amount staked" },
-    { key: "lockTimeTier", label: "Tier" },
-    { key: "lockTime", label: "Unlock time" },
-  ]
 }
-
 </script>
 <style lang="scss" scoped>
 header {

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -2,7 +2,7 @@
   <div class="validation-delegations py-2">
     <h6>
       {{ $t("components.other_delegations.total_staked") }}:
-      {{ totalStaked | tokenAmount(18, 0) }} LOOM
+      {{ totalStaked | tokenAmount(18, 3) }} LOOM
     </h6>
     <div role="tablist" v-if="delegations.length">
       <div v-for="(tier, index) in locktimeTiers">
@@ -19,7 +19,7 @@
               {{ $t("components.other_delegations.lock_time") }} {{ tier }}
             </dt>
             <dd>
-              {{ getSumDelegations(getDelegationsTier(index)) | tokenAmount }}
+              {{ getSumDelegations(getDelegationsTier(index)) | tokenAmount(18, 3) }}
               LOOM
             </dd>
           </dl>
@@ -44,13 +44,10 @@
               {{ data.item.index }}
             </template>
             <template scope="data" slot="amount">
-              {{ data.item.amount | tokenAmount }} LOOM
-            </template>
-            <template scope="data" slot="lockTimeTier">
-              {{ data.item.lockTimeTier | lockTimeTier }}
+              {{ data.item.amount | tokenAmount(18, 3) }} LOOM
             </template>
             <template scope="data" slot="lockTime">
-              {{ data.item.lockTime | date("seconds") }}
+              {{ data.item.lockTime | dateWithoutTime }}
             </template>
           </b-table>
           <b-pagination
@@ -115,15 +112,11 @@ export default class OtherDelegations extends Vue {
       },
       {
         key: "amount",
-        label: this.$t("components.other_delegations.amount_staked").toString(),
-      },
-      {
-        key: "lockTimeTier",
-        label: this.$t("components.other_delegations.tier").toString(),
+        label: this.$t("views.validator_detail.amount_delegated").toString(),
       },
       {
         key: "lockTime",
-        label: this.$t("components.other_delegations.unlock_time").toString(),
+        label: this.$t("views.validator_detail.unlock_time").toString(),
       },
     ]
   }

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="validation-delegations">
-    <!-- <b-card class="mb-4"> -->
     <h6>Total stake: {{ totalStaked | tokenAmount(18, 0) }} LOOM</h6>
     <div role="tablist" v-if="delegations.length">
       <div v-for="(tier, index) in locktimeTiers">
@@ -30,23 +29,33 @@
             hover
             :items="getDelegationsTier(index)"
             :fields="tableFields"
+            :per-page="perPage"
+            :current-page="currentPage"
           >
-            <template scope="item" slot="delegator">
-              loom{{ item.item.delegator.local.toString().substring(2) }}
+            <template scope="data" slot="delegator">
+              loom{{ data.item.delegator.local.toString().substring(2) }}
             </template>
-            <template scope="item" slot="index">
-              {{ item.item.index }}
+            <template scope="data" slot="index">
+              {{ data.item.index }}
             </template>
-            <template scope="item" slot="amount">
-              {{ item.item.amount | tokenAmount }} LOOM
+            <template scope="data" slot="amount">
+              {{ data.item.amount | tokenAmount }} LOOM
             </template>
-            <template scope="item" slot="lockTimeTier">
-              {{ item.item.lockTimeTier | lockTimeTier }}
+            <template scope="data" slot="lockTimeTier">
+              {{ data.item.lockTimeTier | lockTimeTier }}
             </template>
-            <template scope="item" slot="lockTime">
-              {{ item.item.lockTime | date("seconds") }}
+            <template scope="data" slot="lockTime">
+              {{ data.item.lockTime | date("seconds") }}
             </template>
           </b-table>
+          <b-pagination
+            v-model="currentPage"
+            :total-rows="getDelegationsTier(index).length"
+            :per-page="perPage"
+            aria-controls="my-table"
+            v-if="getDelegationsTier(index).length / perPage > 1"
+            align="right"
+          ></b-pagination>
         </b-collapse>
       </div>
     </div>
@@ -64,6 +73,9 @@ import { ZERO } from "@/utils"
 })
 export default class OtherDelegations extends Vue {
   zero = ZERO
+  currentTier = 5
+  perPage = 10
+  currentPage = 1
 
   @Prop({ required: true }) validator!: Validator
 
@@ -79,6 +91,17 @@ export default class OtherDelegations extends Vue {
     return this.validator.allDelegations
   }
 
+  get locktimeTiers() {
+    return [
+      this.$t("components.modals.faucet_delegate_modal.two_weeks").toString(),
+      this.$t(
+        "components.modals.faucet_delegate_modal.three_months"
+      ).toString(),
+      this.$t("components.modals.faucet_delegate_modal.six_months").toString(),
+      this.$t("components.modals.faucet_delegate_modal.one_year").toString(),
+    ]
+  }
+
   getDelegationsTier(tierIndex: number) {
     return this.delegations.filter((d) => d.lockTimeTier === tierIndex)
   }
@@ -91,21 +114,9 @@ export default class OtherDelegations extends Vue {
     return sum
   }
 
-  get locktimeTiers() {
-    return [
-      this.$t("components.modals.faucet_delegate_modal.two_weeks").toString(),
-      this.$t(
-        "components.modals.faucet_delegate_modal.three_months"
-      ).toString(),
-      this.$t("components.modals.faucet_delegate_modal.six_months").toString(),
-      this.$t("components.modals.faucet_delegate_modal.one_year").toString(),
-    ]
-  }
-
-  currentTier = 5
-
   showDetail(selectedTier) {
     this.currentTier = selectedTier
+    this.currentPage = 1
   }
 
   tableFields = [
@@ -116,6 +127,7 @@ export default class OtherDelegations extends Vue {
     { key: "lockTime", label: "Unlock time" },
   ]
 }
+
 </script>
 <style lang="scss" scoped>
 header {

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -25,32 +25,28 @@
           class="mt-2"
           :visible="index == currentTier"
         >
-          <b-card
-            v-for="(delegation, i) in getDelegationsTier(index)"
-            :key="delegation.unlockTime"
-            class="my-2"
+          <b-table
+            striped
+            hover
+            :items="getDelegationsTier(index)"
+            :fields="tableFields"
           >
-            <dl>
-              <dt>delegator</dt>
-              <dd>loom{{validator.address.local.toString().substring(2)}}</dd>
-            </dl>
-            <dl>
-              <dt>delegation index</dt>
-              <dd>{{ delegation.index }}</dd>
-            </dl>
-            <dl>
-              <dt>amount staked</dt>
-              <dd>{{ delegation.amount | tokenAmount }} LOOM</dd>
-            </dl>
-            <dl>
-              <dt>tier</dt>
-              <dd>{{delegation.lockTimeTier | lockTimeTier}}</dd>
-            </dl>
-            <dl>
-              <dt>unlock time</dt>
-              <dd>{{delegation.lockTime | date('seconds')}}</dd>
-            </dl>
-          </b-card>
+            <template scope="item" slot="delegator">
+              loom{{ item.item.delegator.local.toString().substring(2) }}
+            </template>
+            <template scope="item" slot="index">
+              {{ item.item.index }}
+            </template>
+            <template scope="item" slot="amount">
+              {{ item.item.amount | tokenAmount }} LOOM
+            </template>
+            <template scope="item" slot="lockTimeTier">
+              {{ item.item.lockTimeTier | lockTimeTier }}
+            </template>
+            <template scope="item" slot="lockTime">
+              {{ item.item.lockTime | date("seconds") }}
+            </template>
+          </b-table>
         </b-collapse>
       </div>
     </div>
@@ -111,6 +107,14 @@ export default class OtherDelegations extends Vue {
   showDetail(selectedTier) {
     this.currentTier = selectedTier
   }
+
+  tableFields = [
+    { key: "delegator", label: "Delegator" },
+    { key: "index", label: "Delegation index" },
+    { key: "amount", label: "Amount staked" },
+    { key: "lockTimeTier", label: "Tier" },
+    { key: "lockTime", label: "Unlock time" },
+  ]
 }
 </script>
 <style lang="scss" scoped>

--- a/src/dpos/components/OtherDelegations.vue
+++ b/src/dpos/components/OtherDelegations.vue
@@ -47,7 +47,10 @@
               {{ data.item.amount | tokenAmount(18, 3) }} LOOM
             </template>
             <template scope="data" slot="lockTime">
-              {{ data.item.lockTime | dateWithoutTime }}
+              <span v-if="data.item.lockTime != 0">
+                {{ data.item.lockTime | dateWithoutTime }}</span
+              >
+              <span v-else> {{ $t("views.validator_detail.unlocked") }}</span>
             </template>
           </b-table>
           <b-pagination

--- a/src/dpos/components/ValidationDelegations.vue
+++ b/src/dpos/components/ValidationDelegations.vue
@@ -1,0 +1,74 @@
+<template>
+  <b-card class="mb-4">
+      <b-card-body >
+        <!-- <b-list-group-item v-for="usersAirdrop in usersAirdrops" :key="usersAirdrop.airdropID">
+        <dl>
+            <dt>{{$t('components.validation_delegations.airdrop_amount')}}:</dt>
+            <dd>{{usersAirdrop.airdropAmount | tokenAmount(getTokensInfo(usersAirdrop.tokenAddress).decimals)}}</dd>
+            <dt>{{$t('components.validation_delegations.token')}}:</dt>
+            <dd>{{getTokensInfo(usersAirdrop.tokenAddress).name}}</dd>
+            <dt>{{$t('components.validation_delegations.unlock_time')}}:</dt>
+            <dd>{{usersAirdrop.timelock | date('seconds')}}</dd>
+        </dl>
+        <b-button
+          block
+          variant="outline-primary"
+          type="button"
+          @click="withdraw(usersAirdrop.airdropID)"
+          :disabled="isOntimeLocked(usersAirdrop) || usersAirdrop.isWithdrew"
+        >
+        {{$t('components.validation_delegations.withdraw')}}
+        </b-button>
+        </b-list-group-item> -->
+      </b-card-body>
+  </b-card>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from "vue-property-decorator"
+import { DPOSState, HasDPOSState, Delegation, Validator } from "@/dpos/store/types"
+import { Store } from "vuex"
+import { dposModule } from "@/dpos/store"
+import { ZERO } from "@/utils"
+import { plasmaModule } from "@/store/plasma"
+
+@Component
+export default class ValidationDelegations extends Vue {
+
+  zero = ZERO
+  /**
+   * Filter by validator
+   */
+  @Prop({ required: true }) validator!: Validator
+
+
+  get state(): DPOSState {
+    return (this.$store as Store<HasDPOSState>).state.dpos
+  }
+
+}
+</script>
+<style lang="scss" scoped>
+header {
+  font-weight: 500;
+}
+dl {
+  display: flex;
+  flex-wrap: wrap;
+  dt,
+  dd {
+    flex: 50%;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.09);
+    line-height: 24px;
+    padding: 8px 0 8px;
+    margin: 0;
+  }
+  dt {
+    font-weight: normal;
+  }
+  dd {
+    font-weight: 500;
+    text-align: right;
+  }
+}
+</style>

--- a/src/dpos/components/ValidationDelegations.vue
+++ b/src/dpos/components/ValidationDelegations.vue
@@ -6,34 +6,38 @@
       <div v-for="(tier, index) in locktimeTiers">
         <b-button
           block
-          :aria-expanded="visible ? 'true' : 'false'"
           aria-controls="collapse-4"
-          @click="visible = !visible"
+          @click="showDetail(index)"
           class="my-2"
+          v-if="getSumDelegations(getDelegationsTier(index)) > 0"
+          v-b-toggle="'accordion-' + currentTier"
         >
-          <dl v-if="">
+          <dl>
             <dt>Locktime {{ tier }}</dt>
             <dd>
-              {{
-                getSumDelegations(getDelegationsTier(index)) | tokenAmount
-              }}
+              {{ getSumDelegations(getDelegationsTier(index)) | tokenAmount }}
               LOOM
             </dd>
-            <!-- getDelegationsTier(index) -->
           </dl>
         </b-button>
-        <!-- <b-collapse id="collapse-4" v-model="visible" class="mt-2">
-          <b-card
+        <b-collapse
+          :id="'accordion-' + index"
+          class="mt-2"
+          :visible="index == currentTier"
+        >
+          <b-card>
+            <!-- <b-card
             v-for="(delegation, i) in delegations"
             :key="delegation.unlockTime"
-            >I should start open!
+            > -->
+            I should start open! {{ tier }}
 
-            <dl>
+            <!-- <dl>
               <dt>Tier {{ i }}</dt>
               <dd>{{ delegation.amount | tokenAmount }} LOOM</dd>
-            </dl>
+            </dl> -->
           </b-card>
-        </b-collapse> -->
+        </b-collapse>
       </div>
     </div>
   </div>
@@ -44,35 +48,24 @@ import { Vue, Component, Prop } from "vue-property-decorator"
 
 import { Delegation, HasDPOSState, Validator } from "@/dpos/store/types"
 import { ZERO } from "@/utils"
-import { formatTokenAmount } from "@/filters"
 
 @Component({
   components: {},
 })
 export default class ValidationDelegations extends Vue {
   zero = ZERO
-  visible = true
-  /**
-   * Filter by validator
-   */
+
   @Prop({ required: true }) validator!: Validator
-  // delegations = []
 
   get state(): HasDPOSState {
     return this.$store.state
   }
 
   get totalStaked() {
-
-    // console.log("this.state.dpos.delegations,",this.state.dpos);
-    // console.log("this.validator.delegations,",this.validator);
     return this.validator.totalStaked
   }
-  summm = ZERO
 
   get delegations() {
-    
-    // return this.state.dpos.delegations.filter((d) => d.validator.addr === this.validator!.addr)
     return this.validator.allDelegations
   }
 
@@ -97,6 +90,12 @@ export default class ValidationDelegations extends Vue {
       this.$t("components.modals.faucet_delegate_modal.six_months").toString(),
       this.$t("components.modals.faucet_delegate_modal.one_year").toString(),
     ]
+  }
+
+  currentTier = 0
+
+  showDetail(selectedTier) {
+    this.currentTier = selectedTier
   }
 }
 </script>

--- a/src/dpos/components/ValidationDelegations.vue
+++ b/src/dpos/components/ValidationDelegations.vue
@@ -1,51 +1,103 @@
 <template>
-  <b-card class="mb-4">
-      <b-card-body >
-        <!-- <b-list-group-item v-for="usersAirdrop in usersAirdrops" :key="usersAirdrop.airdropID">
-        <dl>
-            <dt>{{$t('components.validation_delegations.airdrop_amount')}}:</dt>
-            <dd>{{usersAirdrop.airdropAmount | tokenAmount(getTokensInfo(usersAirdrop.tokenAddress).decimals)}}</dd>
-            <dt>{{$t('components.validation_delegations.token')}}:</dt>
-            <dd>{{getTokensInfo(usersAirdrop.tokenAddress).name}}</dd>
-            <dt>{{$t('components.validation_delegations.unlock_time')}}:</dt>
-            <dd>{{usersAirdrop.timelock | date('seconds')}}</dd>
-        </dl>
+  <div class="validation-delegations">
+    <!-- <b-card class="mb-4"> -->
+    <h6>Total stake: {{ totalStaked | tokenAmount(18, 0) }} LOOM</h6>
+    <div role="tablist" v-if="delegations.length">
+      <div v-for="(tier, index) in locktimeTiers">
         <b-button
           block
-          variant="outline-primary"
-          type="button"
-          @click="withdraw(usersAirdrop.airdropID)"
-          :disabled="isOntimeLocked(usersAirdrop) || usersAirdrop.isWithdrew"
+          :aria-expanded="visible ? 'true' : 'false'"
+          aria-controls="collapse-4"
+          @click="visible = !visible"
+          class="my-2"
         >
-        {{$t('components.validation_delegations.withdraw')}}
+          <dl v-if="">
+            <dt>Locktime {{ tier }}</dt>
+            <dd>
+              {{
+                getSumDelegations(getDelegationsTier(index)) | tokenAmount
+              }}
+              LOOM
+            </dd>
+            <!-- getDelegationsTier(index) -->
+          </dl>
         </b-button>
-        </b-list-group-item> -->
-      </b-card-body>
-  </b-card>
+        <!-- <b-collapse id="collapse-4" v-model="visible" class="mt-2">
+          <b-card
+            v-for="(delegation, i) in delegations"
+            :key="delegation.unlockTime"
+            >I should start open!
+
+            <dl>
+              <dt>Tier {{ i }}</dt>
+              <dd>{{ delegation.amount | tokenAmount }} LOOM</dd>
+            </dl>
+          </b-card>
+        </b-collapse> -->
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
 import { Vue, Component, Prop } from "vue-property-decorator"
-import { DPOSState, HasDPOSState, Delegation, Validator } from "@/dpos/store/types"
-import { Store } from "vuex"
-import { dposModule } from "@/dpos/store"
+
+import { Delegation, HasDPOSState, Validator } from "@/dpos/store/types"
 import { ZERO } from "@/utils"
-import { plasmaModule } from "@/store/plasma"
+import { formatTokenAmount } from "@/filters"
 
-@Component
+@Component({
+  components: {},
+})
 export default class ValidationDelegations extends Vue {
-
   zero = ZERO
+  visible = true
   /**
    * Filter by validator
    */
   @Prop({ required: true }) validator!: Validator
+  // delegations = []
 
-
-  get state(): DPOSState {
-    return (this.$store as Store<HasDPOSState>).state.dpos
+  get state(): HasDPOSState {
+    return this.$store.state
   }
 
+  get totalStaked() {
+
+    // console.log("this.state.dpos.delegations,",this.state.dpos);
+    // console.log("this.validator.delegations,",this.validator);
+    return this.validator.totalStaked
+  }
+  summm = ZERO
+
+  get delegations() {
+    
+    // return this.state.dpos.delegations.filter((d) => d.validator.addr === this.validator!.addr)
+    return this.validator.allDelegations
+  }
+
+  getDelegationsTier(tierIndex: number) {
+    return this.delegations.filter((d) => d.lockTimeTier === tierIndex)
+  }
+
+  getSumDelegations(delegations: Delegation[]) {
+    let sum = ZERO
+    delegations.forEach((delegation) => {
+      sum = sum.add(delegation.amount)
+    })
+    return sum
+  }
+
+  get locktimeTiers() {
+    return [
+      this.$t("components.modals.faucet_delegate_modal.two_weeks").toString(),
+      this.$t(
+        "components.modals.faucet_delegate_modal.three_months"
+      ).toString(),
+      this.$t("components.modals.faucet_delegate_modal.six_months").toString(),
+      this.$t("components.modals.faucet_delegate_modal.one_year").toString(),
+    ]
+  }
 }
 </script>
 <style lang="scss" scoped>

--- a/src/dpos/components/ValidationDelegations.vue
+++ b/src/dpos/components/ValidationDelegations.vue
@@ -25,17 +25,31 @@
           class="mt-2"
           :visible="index == currentTier"
         >
-          <b-card>
-            <!-- <b-card
-            v-for="(delegation, i) in delegations"
+          <b-card
+            v-for="(delegation, i) in getDelegationsTier(index)"
             :key="delegation.unlockTime"
-            > -->
-            I should start open! {{ tier }}
-
-            <!-- <dl>
-              <dt>Tier {{ i }}</dt>
+            class="my-2"
+          >
+            <dl>
+              <dt>delegator</dt>
+              <dd>loom{{validator.address.local.toString().substring(2)}}</dd>
+            </dl>
+            <dl>
+              <dt>delegation index</dt>
+              <dd>{{ delegation.index }}</dd>
+            </dl>
+            <dl>
+              <dt>amount staked</dt>
               <dd>{{ delegation.amount | tokenAmount }} LOOM</dd>
-            </dl> -->
+            </dl>
+            <dl>
+              <dt>tier</dt>
+              <dd>{{delegation.lockTimeTier | lockTimeTier}}</dd>
+            </dl>
+            <dl>
+              <dt>unlock time</dt>
+              <dd>{{delegation.lockTime | date('seconds')}}</dd>
+            </dl>
           </b-card>
         </b-collapse>
       </div>
@@ -92,7 +106,7 @@ export default class ValidationDelegations extends Vue {
     ]
   }
 
-  currentTier = 0
+  currentTier = 5
 
   showDetail(selectedTier) {
     this.currentTier = selectedTier

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -15,6 +15,7 @@ export function initFilters() {
   Vue.filter("lockTimeBonus", formatLockTimeBonus)
   // Vue.filter('duration', formatDuration)
   Vue.filter("date", formatDate)
+  Vue.filter("dateWithoutTime", dateWithoutTime)
   Vue.filter("readableDate", readableDateTime)
   Vue.filter("bn", formatBN)
   Vue.filter("bigNumber", formatBigNumber)
@@ -59,6 +60,16 @@ export function formatDate(timestamp) {
 export function readableDateTime(timestamp) {
   console.log("date", timestamp)
   return new Date(timestamp * 1000).toLocaleDateString()
+}
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "long",
+  day: "numeric"
+})
+export function dateWithoutTime(timestamp) {
+  return DATE_FORMAT.format(new Date(parseInt("" + timestamp, 10) * 1000))
+
 }
 
 /**

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -64,7 +64,7 @@ export function readableDateTime(timestamp) {
 
 const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
   year: "numeric",
-  month: "long",
+  month: "short",
   day: "numeric"
 })
 export function dateWithoutTime(timestamp) {

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -65,7 +65,7 @@ export function readableDateTime(timestamp) {
 const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
   year: "numeric",
   month: "short",
-  day: "numeric"
+  day: "numeric",
 })
 export function dateWithoutTime(timestamp) {
   return DATE_FORMAT.format(new Date(parseInt("" + timestamp, 10) * 1000))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -405,7 +405,8 @@
       "resume_deposit": "Resume Deposit",
       "election_cycle": "Election Cycle",
       "time_left": "Time left",
-      "delegations": "Delegations"
+      "delegations": "Delegations",
+      "validation_delegations": "Validation Delegations"
     },
     "transfer_gateway": {
       "connect_new_contracts": "Connect New Contracts",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -405,8 +405,8 @@
       "resume_deposit": "Resume Deposit",
       "election_cycle": "Election Cycle",
       "time_left": "Time left",
-      "delegations": "Delegations",
-      "validation_delegations": "Validation Delegations"
+      "validator_delegations": "Validator Delegations",
+      "other_delegations": "Other Delegations"
     },
     "transfer_gateway": {
       "connect_new_contracts": "Connect New Contracts",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -810,6 +810,15 @@
       "max_referral_percentage": "Max Referral",
       "wait_change_fee_state": "Update already in progress, please try changing the fee after the next election.",
       "validate_fee": "Fee must be between {min}% and {max}%."
+    },
+    "other_delegations": {
+      "total_staked": "Total staked",
+      "lock_time": "Lock time",
+      "delegator": "Delegator",
+      "delegation_index": "Delegation index",
+      "amount_staked": "Amount staked",
+      "tier": "Tier",
+      "unlock_time": "Unlock time"
     }
   },
   "events": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -812,13 +812,10 @@
       "validate_fee": "Fee must be between {min}% and {max}%."
     },
     "other_delegations": {
-      "total_staked": "Total staked",
-      "lock_time": "Lock time",
+      "total_staked": "Total Staked",
+      "lock_time": "Lock Time",
       "delegator": "Delegator",
-      "delegation_index": "Delegation index",
-      "amount_staked": "Amount staked",
-      "tier": "Tier",
-      "unlock_time": "Unlock time"
+      "delegation_index": "Index"
     }
   },
   "events": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -350,7 +350,8 @@
       "resume_deposit": "Resume Deposit",
       "election_cycle": "Election Cycle",
       "time_left": "Time left",
-      "delegations": "Delegations"
+      "validator_delegations": "Validator Delegations",
+      "other_delegations": "Other Delegations"
     },
     "transfer_gateway": {
       "connect_new_contracts": "Connect New Contracts",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -755,6 +755,15 @@
       "max_referral_percentage": "Max Referral",
       "wait_change_fee_state": "Update already in progress, please try changing the fee after the next election.",
       "validate_fee": "Fee must be between {min}% and {max}%."
+    },
+    "other_delegations": {
+      "total_staked": "Total staked",
+      "lock_time": "Lock time",
+      "delegator": "Delegator",
+      "delegation_index": "Delegation index",
+      "amount_staked": "Amount staked",
+      "tier": "Tier",
+      "unlock_time": "Unlock time"
     }
   },
   "events": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -757,13 +757,10 @@
       "validate_fee": "Fee must be between {min}% and {max}%."
     },
     "other_delegations": {
-      "total_staked": "Total staked",
-      "lock_time": "Lock time",
+      "total_staked": "Total Staked",
+      "lock_time": "Lock Time",
       "delegator": "Delegator",
-      "delegation_index": "Delegation index",
-      "amount_staked": "Amount staked",
-      "tier": "Tier",
-      "unlock_time": "Unlock time"
+      "delegation_index": "Index"
     }
   },
   "events": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -350,7 +350,8 @@
       "resume_deposit": "Resume Deposit",
       "election_cycle": "Election Cycle",
       "time_left": "Time left",
-      "delegations": "Delegations"
+      "validator_delegations": "Validator Delegations",
+      "other_delegations": "Other Delegations"
     },
     "transfer_gateway": {
       "connect_new_contracts": "Connect New Contracts",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -755,6 +755,15 @@
       "max_referral_percentage": "Max Referral",
       "wait_change_fee_state": "Update already in progress, please try changing the fee after the next election.",
       "validate_fee": "Fee must be between {min}% and {max}%."
+    },
+    "other_delegations": {
+      "total_staked": "Total staked",
+      "lock_time": "Lock time",
+      "delegator": "Delegator",
+      "delegation_index": "Delegation index",
+      "amount_staked": "Amount staked",
+      "tier": "Tier",
+      "unlock_time": "Unlock time"
     }
   },
   "events": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -757,13 +757,10 @@
       "validate_fee": "Fee must be between {min}% and {max}%."
     },
     "other_delegations": {
-      "total_staked": "Total staked",
-      "lock_time": "Lock time",
+      "total_staked": "Total Staked",
+      "lock_time": "Lock Time",
       "delegator": "Delegator",
-      "delegation_index": "Delegation index",
-      "amount_staked": "Amount staked",
-      "tier": "Tier",
-      "unlock_time": "Unlock time"
+      "delegation_index": "Index"
     }
   },
   "events": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -755,6 +755,15 @@
       "max_referral_percentage": "Max Referral",
       "wait_change_fee_state": "Update already in progress, please try changing the fee after the next election.",
       "validate_fee": "Fee must be between {min}% and {max}%."
+    },
+    "other_delegations": {
+      "total_staked": "Total staked",
+      "lock_time": "Lock time",
+      "delegator": "Delegator",
+      "delegation_index": "Delegation index",
+      "amount_staked": "Amount staked",
+      "tier": "Tier",
+      "unlock_time": "Unlock time"
     }
   },
   "events": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -757,13 +757,10 @@
       "validate_fee": "Fee must be between {min}% and {max}%."
     },
     "other_delegations": {
-      "total_staked": "Total staked",
-      "lock_time": "Lock time",
+      "total_staked": "Total Staked",
+      "lock_time": "Lock Time",
       "delegator": "Delegator",
-      "delegation_index": "Delegation index",
-      "amount_staked": "Amount staked",
-      "tier": "Tier",
-      "unlock_time": "Unlock time"
+      "delegation_index": "Index"
     }
   },
   "events": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -350,7 +350,8 @@
       "resume_deposit": "입금 계속하기",
       "election_cycle": "선거 주기",
       "time_left": "남은 기간",
-      "delegations": "위임 내역"
+      "validator_delegations": "Validator Delegations",
+      "other_delegations": "Other Delegations"
     },
     "transfer_gateway": {
       "connect_new_contracts": "새 컨트랙트 연결",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -754,6 +754,15 @@
       "max_referral_percentage": "Max Referral",
       "wait_change_fee_state": "Update already in progress, please try changing the fee after the next election.",
       "validate_fee": "Fee must be between {min}% and {max}%."
+    },
+    "other_delegations": {
+      "total_staked": "Total staked",
+      "lock_time": "Lock time",
+      "delegator": "Delegator",
+      "delegation_index": "Delegation index",
+      "amount_staked": "Amount staked",
+      "tier": "Tier",
+      "unlock_time": "Unlock time"
     }
   },
   "events": {

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -756,13 +756,10 @@
       "validate_fee": "Fee must be between {min}% and {max}%."
     },
     "other_delegations": {
-      "total_staked": "Total staked",
-      "lock_time": "Lock time",
+      "total_staked": "Total Staked",
+      "lock_time": "Lock Time",
       "delegator": "Delegator",
-      "delegation_index": "Delegation index",
-      "amount_staked": "Amount staked",
-      "tier": "Tier",
-      "unlock_time": "Unlock time"
+      "delegation_index": "Index"
     }
   },
   "events": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -755,6 +755,15 @@
       "max_referral_percentage": "Max Referral",
       "wait_change_fee_state": "Update already in progress, please try changing the fee after the next election.",
       "validate_fee": "Fee must be between {min}% and {max}%."
+    },
+    "other_delegations": {
+      "total_staked": "Total staked",
+      "lock_time": "Lock time",
+      "delegator": "Delegator",
+      "delegation_index": "Delegation index",
+      "amount_staked": "Amount staked",
+      "tier": "Tier",
+      "unlock_time": "Unlock time"
     }
   },
   "events": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -757,13 +757,10 @@
       "validate_fee": "Fee must be between {min}% and {max}%."
     },
     "other_delegations": {
-      "total_staked": "Total staked",
-      "lock_time": "Lock time",
+      "total_staked": "Total Staked",
+      "lock_time": "Lock Time",
       "delegator": "Delegator",
-      "delegation_index": "Delegation index",
-      "amount_staked": "Amount staked",
-      "tier": "Tier",
-      "unlock_time": "Unlock time"
+      "delegation_index": "Index"
     }
   },
   "events": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -350,7 +350,8 @@
       "resume_deposit": "继续未完成的存入",
       "election_cycle": "选举周期",
       "time_left": "剩下时间",
-      "delegations": "委托"
+      "validator_delegations": "Validator Delegations",
+      "other_delegations": "Other Delegations"
     },
     "transfer_gateway": {
       "connect_new_contracts": "连接新合约",

--- a/src/views/MobileAccount.vue
+++ b/src/views/MobileAccount.vue
@@ -62,7 +62,7 @@
 
     <b-card id="delegations-container" no-body>
       <b-card-body>
-        <h4 class="card-title" style="margin: 0;">{{ $t('views.mobile_account.delegations') }}</h4>
+        <h4 class="card-title" style="margin: 0;">{{ $t('views.mobile_account.validator_delegations') }}</h4>
       </b-card-body>
       <delegations :delegations="delegations" show-validator />
     </b-card>
@@ -75,8 +75,8 @@
       <b-button @click="$router.push({ path: '/validators' })">{{ $t('views.validator_detail.stake_tokens') }}</b-button>
     </div>
 
-    <b-card :title="$t('views.mobile_account.validation_delegations')" v-if="validator">
-      <ValidationDelegations :validator="validator" />
+    <b-card :title="$t('views.mobile_account.other_delegations')" v-if="validator">
+      <OtherDelegations :validator="validator" />
     </b-card>
   </div>
 </template>
@@ -96,7 +96,7 @@ import ElectionTimer from "@/dpos/components/ElectionTimer.vue"
 import Delegations from "@/dpos/components/Delegations.vue"
 import { Subscription, timer } from "rxjs"
 import Airdrop from "@/dpos/components/Airdrop.vue"
-import ValidationDelegations from "@/dpos/components/ValidationDelegations.vue"
+import OtherDelegations from "@/dpos/components/OtherDelegations.vue"
 
 const log = debug("mobileaccount")
 
@@ -108,7 +108,7 @@ const log = debug("mobileaccount")
     ElectionTimer,
     Delegations,
     Airdrop,
-    ValidationDelegations,
+    OtherDelegations,
   },
 })
 export default class MobileAccount extends Vue {

--- a/src/views/MobileAccount.vue
+++ b/src/views/MobileAccount.vue
@@ -71,9 +71,13 @@
       {{state.dpos.unclaimedTokens}}
     </pre> -->
 
-    <div class="button-container">
+    <div class="button-container mb-4">
       <b-button @click="$router.push({ path: '/validators' })">{{ $t('views.validator_detail.stake_tokens') }}</b-button>
     </div>
+
+    <b-card :title="$t('views.mobile_account.validation_delegations')" v-if="validator">
+      <ValidationDelegations :validator="validator" />
+    </b-card>
   </div>
 </template>
 
@@ -92,6 +96,7 @@ import ElectionTimer from "@/dpos/components/ElectionTimer.vue"
 import Delegations from "@/dpos/components/Delegations.vue"
 import { Subscription, timer } from "rxjs"
 import Airdrop from "@/dpos/components/Airdrop.vue"
+import ValidationDelegations from "@/dpos/components/ValidationDelegations.vue"
 
 const log = debug("mobileaccount")
 
@@ -103,6 +108,7 @@ const log = debug("mobileaccount")
     ElectionTimer,
     Delegations,
     Airdrop,
+    ValidationDelegations,
   },
 })
 export default class MobileAccount extends Vue {
@@ -119,6 +125,13 @@ export default class MobileAccount extends Vue {
   refreshTimer: Subscription | null = null
 
   get delegations() { return this.state.dpos.delegations }
+
+  get validator() {
+    const myValidator = this.state.dpos.validators.find((validator) => {
+      return validator.addr === this.state.plasma.address
+    })
+    return myValidator ? myValidator : false
+  }
 
   toggleAccordion(idx) {
     this.$root.$emit("bv::toggle::collapse", "accordion" + idx)


### PR DESCRIPTION
Currently when you login as a validator on the dashboard you'll only see the self-delegations in the `Delegations` section of `My Account`:
![image](https://user-images.githubusercontent.com/233003/122163033-bf071880-ce9e-11eb-8d33-78cb034752d6.png)

We need to add another section below that to display delegations to the validator from other users. This new section should just show a summary on first load (X LOOM staked in total, Y LOOM staked at Tier 0, Z LOOM staked at Tier 1 etc.), and there should be a button that displays a list of all the delegations (a table, with columns for delegator, delegation index, amount staked, tier, and unlock time).